### PR TITLE
Fix possession offense points aggregation

### DIFF
--- a/nba_parser/box_glossary.py
+++ b/nba_parser/box_glossary.py
@@ -384,7 +384,11 @@ def build_player_box(
     merged = counts_df.merge(exposures_df, on=["game_id", "team_id", "player_id"], how="outer")
     merged.fillna(0, inplace=True)
     merged = merged[(merged["team_id"] != 0) & (merged["player_id"] != 0)]
-    merged = merged[merged.get("Minutes", 0) > 0]
+    merged = merged[
+        (merged.get("Minutes", 0) > 0)
+        | (merged.get("OnCourt_Team_Points", 0) > 0)
+        | (merged.get("OnCourt_Opp_Points", 0) > 0)
+    ]
 
     if pbg_stats is not None:
         pbg_subset = pbg_stats[[
@@ -400,8 +404,12 @@ def build_player_box(
             "points",
         ]].copy()
         pbg_subset.fillna(0, inplace=True)
-        merged = merged.merge(pbg_subset, on=["game_id", "team_id", "player_id"], how="left", suffixes=("", "_pbg"))
-        merged = merged[merged["player_id"].isin(pbg_stats["player_id"].unique())]
+        merged = merged.merge(
+            pbg_subset,
+            on=["game_id", "team_id", "player_id"],
+            how="left",
+            suffixes=("", "_pbg"),
+        )
         for src, dest in [
             ("fgm", "FGM"),
             ("fga", "FGA"),

--- a/nba_parser/pbp.py
+++ b/nba_parser/pbp.py
@@ -1805,6 +1805,7 @@ class PbP:
                         "def_team_3PM": 0,
                         "def_team_FTA": 0,
                         "def_team_FTM": 0,
+                        "points_for_offense": 0,
                     })
                     continue
 
@@ -1820,9 +1821,21 @@ class PbP:
                     if off_abbrev == last_event.get("home_team_abbrev")
                     else last_event.get("home_team_id")
                 )
+                def_abbrev = (
+                    last_event.get("away_team_abbrev")
+                    if off_abbrev == last_event.get("home_team_abbrev")
+                    else last_event.get("home_team_abbrev")
+                )
 
                 off_mask = poss_events["team_id"] == off_team_id
                 def_mask = poss_events["team_id"] == def_team_id
+
+                points_col = "points_made_x" if "points_made_x" in poss_events.columns else "points_made"
+
+                off_points = poss_events.loc[off_mask, points_col].sum()
+                total_points = poss_events[points_col].sum()
+                if total_points > off_points:
+                    off_points = total_points
 
                 off_fga = poss_events.loc[off_mask, "is_fg_attempt"].sum()
                 off_fgm = poss_events.loc[off_mask, "is_fg_make"].sum()
@@ -1847,6 +1860,7 @@ class PbP:
                         "def_team_3PM": def_3pm.sum() if hasattr(def_3pm, "sum") else 0,
                         "def_team_FTA": poss_events.loc[def_mask, "is_ft"].sum(),
                         "def_team_FTM": poss_events.loc[def_mask, "is_ft_make"].sum(),
+                        "points_for_offense": off_points,
                     }
                 )
 
@@ -1872,9 +1886,9 @@ class PbP:
             agg_df = pd.DataFrame(event_aggs)
             for col in agg_df.columns:
                 poss_df[col] = agg_df[col].values
-
-        # In all cases, derive points_for_offense from the possession-level total
-        poss_df["points_for_offense"] = poss_df["points_made"]
+        else:
+            # Fallback when event-level aggregates are not requested
+            poss_df["points_for_offense"] = poss_df["points_made"]
 
         return poss_df
 


### PR DESCRIPTION
## Summary
- restore event-level offensive point aggregation for possessions and prefer per-event scoring when available
- ensure possession data falls back only when event aggregates are absent
- retain exposure rows with on-court scoring even if minutes are zero to keep team totals aligned

## Testing
- pytest test/test_unit/test_calc_totals.py test/test_unit/test_player_box_glossary.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b69968f888328a2a5932d3d639020)