### PR TITLE
Handle event-level scoring per possession

### DIFF
--- a/nba_parser/box_glossary.py
+++ b/nba_parser/box_glossary.py
@@ -53,8 +53,14 @@ def annotate_events(df: pd.DataFrame) -> pd.DataFrame:
                 np.nan,
             ),
         )
-    if "points_made" not in df.columns and "points_made_y" in df.columns:
-        df["points_made"] = df["points_made_y"]
+    # Prefer event-level points_made_x if present (e.g., after a merge that
+    # produced points_made_x / points_made_y). Otherwise fall back to the
+    # aggregate points_made_y, or leave any existing points_made untouched.
+    if "points_made" not in df.columns:
+        if "points_made_x" in df.columns:
+            df["points_made"] = df["points_made_x"]
+        elif "points_made_y" in df.columns:
+            df["points_made"] = df["points_made_y"]
     fam = df["family"].astype(str).str.lower().str.replace("-", "_", regex=False)
     df["family"] = fam
 
@@ -65,7 +71,11 @@ def annotate_events(df: pd.DataFrame) -> pd.DataFrame:
     df["is_three"] = df.get("is_three", 0).astype(bool)
 
     is_tov_family = fam == "turnover"
-    subfam = df.get("subfamily_de", "").fillna("") if "subfamily_de" in df.columns else pd.Series([""] * len(df))
+    if "subfamily_de" in df.columns:
+        subfam = df["subfamily_de"].fillna("")
+    else:
+        # Ensure index alignment if df has a non-default index
+        subfam = pd.Series([""] * len(df), index=df.index)
     df["is_turnover_live"] = is_tov_family & subfam.str.contains("live", case=False)
     df["is_turnover_dead"] = is_tov_family & ~df["is_turnover_live"]
     df.loc[is_tov_family & ~subfam.astype(bool), "is_turnover_live"] = (
@@ -298,6 +308,7 @@ def compute_on_court_exposures(pbp: "PbP", df: pd.DataFrame) -> pd.DataFrame:
         off_team = poss.get("off_team_id")
         def_team = poss.get("def_team_id")
         points = poss.get("points_for_offense", 0)
+        def_points = poss.get("points_for_defense", 0)
         off_players = [poss.get(f"off_player_{i}_id") for i in range(1, 6)]
         def_players = [poss.get(f"def_player_{i}_id") for i in range(1, 6)]
 
@@ -306,6 +317,7 @@ def compute_on_court_exposures(pbp: "PbP", df: pd.DataFrame) -> pd.DataFrame:
                 key = (poss.get("game_id"), off_team, pid)
                 _increment_count(exposures[key], "POSS_OFF")
                 _increment_count(exposures[key], "OnCourt_Team_Points", points)
+                _increment_count(exposures[key], "OnCourt_Opp_Points", def_points)
                 _increment_count(exposures[key], "OnCourt_Team_3p_Att", poss.get("off_team_3PA", 0))
                 _increment_count(exposures[key], "OnCourt_Team_3p_Made", poss.get("off_team_3PM", 0))
                 _increment_count(exposures[key], "OnCourt_Team_FT_Att", poss.get("off_team_FTA", 0))
@@ -317,6 +329,7 @@ def compute_on_court_exposures(pbp: "PbP", df: pd.DataFrame) -> pd.DataFrame:
                 key = (poss.get("game_id"), def_team, pid)
                 _increment_count(exposures[key], "POSS_DEF")
                 _increment_count(exposures[key], "OnCourt_Opp_Points", points)
+                _increment_count(exposures[key], "OnCourt_Team_Points", def_points)
                 _increment_count(exposures[key], "OnCourt_Opp_3p_Att", poss.get("off_team_3PA", 0))
                 _increment_count(exposures[key], "OnCourt_Opp_3p_Made", poss.get("off_team_3PM", 0))
                 _increment_count(exposures[key], "OnCourt_Opp_FT_Att", poss.get("off_team_FTA", 0))
@@ -360,7 +373,9 @@ def compute_on_court_exposures(pbp: "PbP", df: pd.DataFrame) -> pd.DataFrame:
             how="left",
         )
         exposure_df["Minutes"] = np.where(
-            exposure_df["Minutes"] == 0, exposure_df["Minutes_calc"], exposure_df["Minutes"]
+            exposure_df["Minutes"] == 0,
+            exposure_df["Minutes_calc"].fillna(0),
+            exposure_df["Minutes"],
         )
         exposure_df.drop(columns=["Minutes_calc"], inplace=True)
     except Exception:
@@ -401,7 +416,13 @@ def build_player_box(
     # if not zero_minute_with_points.empty:
     #     print("Zero-minute rows with on-court points:\n", zero_minute_with_points)
 
-    merged = merged[merged.get("Minutes", 0) > 0]
+    merged = merged[
+        (merged.get("Minutes", 0) > 0)
+        | (
+            (merged.get("OnCourt_Team_Points", 0) != 0)
+            | (merged.get("OnCourt_Opp_Points", 0) != 0)
+        )
+    ]
 
     if pbg_stats is not None:
         pbg_subset = pbg_stats[[

--- a/nba_parser/pbp.py
+++ b/nba_parser/pbp.py
@@ -1806,6 +1806,7 @@ class PbP:
                         "def_team_FTA": 0,
                         "def_team_FTM": 0,
                         "points_for_offense": 0,
+                        "points_for_defense": 0,
                     })
                     continue
 
@@ -1821,50 +1822,17 @@ class PbP:
                     if off_abbrev == last_event.get("home_team_abbrev")
                     else last_event.get("home_team_id")
                 )
-                def_abbrev = (
-                    last_event.get("away_team_abbrev")
-                    if off_abbrev == last_event.get("home_team_abbrev")
-                    else last_event.get("home_team_abbrev")
-                )
-
                 off_mask = poss_events["team_id"] == off_team_id
                 def_mask = poss_events["team_id"] == def_team_id
-
-                # Use possession-level points after annotate_events:
-                # - annotate_events ensures a "points_made" column that reflects
-                #   the total points scored at each (game_id, seconds_elapsed).
-                # - off_mask selects rows belonging to the offensive team.
-                scoring_mask = poss_events["points_made"] > 0
+                # After annotate_events, "points_made" is event-level scoring
+                # (prefer points_made_x if present). So offensive points for the
+                # possession are just the sum of those events for the offense.
+                points_col = "points_made"
                 if "points_made_x" in poss_events.columns:
-                    scoring_mask &= poss_events["points_made_x"] > 0
-
-                def _sum_unique(mask: pd.Series) -> float:
-                    scoring_events = poss_events.loc[
-                        mask,
-                        ["game_id", "seconds_elapsed", "team_id", "points_made"],
-                    ]
-                    if scoring_events.empty:
-                        return 0.0
-                    unique_scoring = scoring_events.drop_duplicates(
-                        subset=["game_id", "seconds_elapsed", "team_id"]
-                    )
-                    return unique_scoring["points_made"].sum()
-
-                off_points = _sum_unique(off_mask & scoring_mask)
-                if off_points == 0 and "points_made_x" not in poss_events.columns:
-                    # Fallback when we lack per-event scoring metadata.
-                    off_points = _sum_unique(off_mask & (poss_events["points_made"] > 0))
-
-                # Optional sanity check: any scoring outside the offensive team
-                # indicates a bug in possession parsing or team attribution.
-                debug_total_points = _sum_unique(scoring_mask)
-                if debug_total_points != off_points:
-                    # TODO: tighten this to an assertion once all edge cases are fixed.
-                    # For now this is a debug hook; you can log or inspect these cases.
-                    # Example:
-                    # print("Possession scoring mismatch",
-                    #       poss_events[["game_id", "seconds_elapsed", "team_id", "points_made"]])
-                    pass
+                    points_col = "points_made_x"
+                scoring_by_team = poss_events.groupby("team_id")[points_col].sum()
+                off_points = scoring_by_team.get(off_team_id, 0)
+                def_points = scoring_by_team.get(def_team_id, 0)
 
                 off_fga = poss_events.loc[off_mask, "is_fg_attempt"].sum()
                 off_fgm = poss_events.loc[off_mask, "is_fg_make"].sum()
@@ -1890,6 +1858,7 @@ class PbP:
                         "def_team_FTA": poss_events.loc[def_mask, "is_ft"].sum(),
                         "def_team_FTM": poss_events.loc[def_mask, "is_ft_make"].sum(),
                         "points_for_offense": off_points,
+                        "points_for_defense": def_points,
                     }
                 )
 
@@ -1918,6 +1887,7 @@ class PbP:
         else:
             # Fallback when event-level aggregates are not requested
             poss_df["points_for_offense"] = poss_df["points_made"]
+            poss_df["points_for_defense"] = 0
 
         return poss_df
 


### PR DESCRIPTION
## Summary
- prioritize event-level `points_made_x` during event annotation and keep subfamily alignment safe when indices differ
- simplify possession scoring to sum event-level points per team, tracking defensive scoring too
- carry defensive scoring into on-court exposures and retain zero-minute rows with credited points

## Testing
- pytest test/test_unit/test_player_box_glossary.py test/test_unit/test_calc_totals.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b8de1ea34832882ecdf46091bd897)