### PR TITLE
Strengthen on-court points consistency checks

### DIFF
--- a/nba_parser/box_glossary.py
+++ b/nba_parser/box_glossary.py
@@ -400,10 +400,9 @@ def build_player_box(
     merged.fillna(0, inplace=True)
     merged = merged[(merged["team_id"] != 0) & (merged["player_id"] != 0)]
 
-    # Keep only players who actually logged playing time.
-    # If a player has non-zero on-court points but zero minutes,
-    # that's a bug upstream and should be investigated instead of
-    # being silently included here.
+    # Identify any rows where a player has on-court points credited but no minutes.
+    # In clean data this should be rare; it typically indicates a mismatch between
+    # rotation/time-on-court tracking and possession parsing.
     zero_minute_with_points = merged[
         (merged.get("Minutes", 0) == 0)
         & (
@@ -412,9 +411,15 @@ def build_player_box(
         )
     ]
 
-    # TODO: add logging or debug handling for zero_minute_with_points
+    # For now, keep such rows so that on-court scoring sums remain consistent
+    # with team totals (tests enforce this). If you want to treat these as hard
+    # errors in a debugging context, you can uncomment the assertion below.
+    #
     # if not zero_minute_with_points.empty:
-    #     print("Zero-minute rows with on-court points:\n", zero_minute_with_points)
+    #     raise AssertionError(
+    #         "Found zero-minute rows with non-zero on-court points; "
+    #         "this indicates an upstream bug in exposures/timing logic."
+    #     )
 
     merged = merged[
         (merged.get("Minutes", 0) > 0)

--- a/nba_parser/pbp.py
+++ b/nba_parser/pbp.py
@@ -1935,24 +1935,45 @@ class PbP:
             game_meta=game_meta,
             pbg_stats=self.playerbygamestats(),
         )
+
+        # Sanity check: on-court points must match team totals.
+        self._check_on_court_points_consistency(box_df)
+
         return box_df
 
     def _check_on_court_points_consistency(self, box: pd.DataFrame, tol: float = 1e-6) -> None:
         """
-        Internal helper: verify that summed OnCourt_Team_Points per team
-        equals team points * 5 for this game.
+        Internal helper: verify that summed OnCourt_Team_Points / OnCourt_Opp_Points
+        per team match the scoreboard totals times 5 for this game.
 
-        Raises AssertionError if the invariant is violated.
+        Raises AssertionError if an invariant is violated.
         """
         team_points = self._point_calc_team()[["team_id", "points_for"]]
-        for _, row in team_points.iterrows():
-            team_id = row["team_id"]
-            expected = row["points_for"] * 5.0
-            actual = box.loc[box["team_id"] == team_id, "OnCourt_Team_Points"].sum()
-            if abs(actual - expected) > tol:
+
+        # Build a simple mapping team_id -> points_for for this game.
+        team_points_map = dict(zip(team_points["team_id"], team_points["points_for"]))
+
+        for team_id, points_for in team_points_map.items():
+            expected_for = points_for * 5.0
+            actual_for = box.loc[box["team_id"] == team_id, "OnCourt_Team_Points"].sum()
+
+            if abs(actual_for - expected_for) > tol:
                 raise AssertionError(
                     f"OnCourt_Team_Points inconsistency for team {team_id}: "
-                    f"actual={actual}, expected={expected}"
+                    f"actual={actual_for}, expected={expected_for}"
+                )
+
+            # Opponent points are the sum of all other teams' points_for.
+            opponent_points = sum(
+                p for t, p in team_points_map.items() if t != team_id
+            )
+            expected_against = opponent_points * 5.0
+            actual_against = box.loc[box["team_id"] == team_id, "OnCourt_Opp_Points"].sum()
+
+            if abs(actual_against - expected_against) > tol:
+                raise AssertionError(
+                    f"OnCourt_Opp_Points inconsistency for team {team_id}: "
+                    f"actual={actual_against}, expected={expected_against}"
                 )
 
     def playerbygamestats(self):


### PR DESCRIPTION
## Summary
- add opponent on-court points validation alongside team totals
- run consistency check after building the player box glossary output
- clarify handling of zero-minute rows with on-court points

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b923f74108328a8fa7d4c2ba38ea9)