### PR TITLE
Harden exposure minutes handling and possession validation

### DIFF
--- a/nba_parser/box_glossary.py
+++ b/nba_parser/box_glossary.py
@@ -307,6 +307,10 @@ def compute_on_court_exposures(pbp: "PbP", df: pd.DataFrame) -> pd.DataFrame:
     for _, poss in poss_df.iterrows():
         off_team = poss.get("off_team_id")
         def_team = poss.get("def_team_id")
+
+        # Skip malformed possessions where we can't reliably assign a team.
+        if pd.isna(off_team) or pd.isna(def_team) or off_team == 0 or def_team == 0:
+            continue
         points = poss.get("points_for_offense", 0)
         def_points = poss.get("points_for_defense", 0)
         off_players = [poss.get(f"off_player_{i}_id") for i in range(1, 6)]
@@ -372,11 +376,10 @@ def compute_on_court_exposures(pbp: "PbP", df: pd.DataFrame) -> pd.DataFrame:
             on=["player_id", "team_id", "game_id"],
             how="left",
         )
-        exposure_df["Minutes"] = np.where(
-            exposure_df["Minutes"] == 0,
-            exposure_df["Minutes_calc"].fillna(0),
-            exposure_df["Minutes"],
-        )
+        minutes = exposure_df["Minutes"].astype(float)
+        minutes_calc = exposure_df["Minutes_calc"].astype(float)
+        minutes = np.where(minutes == 0.0, minutes_calc.fillna(0.0), minutes)
+        exposure_df["Minutes"] = minutes
         exposure_df.drop(columns=["Minutes_calc"], inplace=True)
     except Exception:
         pass
@@ -420,6 +423,15 @@ def build_player_box(
     #         "Found zero-minute rows with non-zero on-court points; "
     #         "this indicates an upstream bug in exposures/timing logic."
     #     )
+    if not zero_minute_with_points.empty:
+        import warnings
+
+        warnings.warn(
+            "Found zero-minute rows with non-zero on-court points; "
+            "this indicates a mismatch between timing and exposures. "
+            "Rows are kept to preserve on-court scoring invariants.",
+            RuntimeWarning,
+        )
 
     merged = merged[
         (merged.get("Minutes", 0) > 0)

--- a/test/test_unit/test_player_box_glossary.py
+++ b/test/test_unit/test_player_box_glossary.py
@@ -35,9 +35,15 @@ def test_player_box_glossary_basics():
         assert abs(minutes - game_minutes * 5) < 1.0
 
     team_points = pbp._point_calc_team()[["team_id", "points_for"]]
-    for _, row in team_points.iterrows():
-        team_total = box.loc[box["team_id"] == row["team_id"], "OnCourt_Team_Points"].sum()
-        assert abs(team_total - row["points_for"] * 5) < 1e-6
+    team_points_map = dict(zip(team_points["team_id"], team_points["points_for"]))
+
+    for team_id, pts_for in team_points_map.items():
+        team_total_for = box.loc[box["team_id"] == team_id, "OnCourt_Team_Points"].sum()
+        assert abs(team_total_for - pts_for * 5) < 1e-6
+
+        opp_points = sum(p for t, p in team_points_map.items() if t != team_id)
+        team_total_against = box.loc[box["team_id"] == team_id, "OnCourt_Opp_Points"].sum()
+        assert abs(team_total_against - opp_points * 5) < 1e-6
 
     pbg = pbp.playerbygamestats()
     merged = box.merge(


### PR DESCRIPTION
## Summary
- keep minutes merging in exposures float-safe to avoid dtype issues and NaNs
- skip malformed possessions lacking team IDs and warn on zero-minute rows with scoring
- extend glossary unit test to assert opponent on-court points consistency

## Testing
- pytest test/test_unit/test_player_box_glossary.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b943ab9f88328b30b31ef3b66712a)