### PR TITLE
Fix turnover live-ball detection and possession scoring alias

### DIFF
--- a/nba_parser/box_glossary.py
+++ b/nba_parser/box_glossary.py
@@ -99,16 +99,16 @@ def annotate_events(df: pd.DataFrame) -> pd.DataFrame:
 
     # --- Turnover live/dead ---
     is_tov_family = fam == "turnover"
-    df["is_turnover_live"] = is_tov_family & subfam.str.contains("live", case=False)
-    df["is_turnover_dead"] = is_tov_family & ~df["is_turnover_live"]
 
-    no_subfamily = ~subfam.astype(bool)
-    df.loc[is_tov_family & no_subfamily, "is_turnover_live"] = (
-        is_tov_family & (df.get("is_steal", 0) == 1)
-    )
-    df.loc[is_tov_family & no_subfamily, "is_turnover_dead"] = (
-        is_tov_family & ~df["is_turnover_live"]
-    )
+    # Anything recorded as a steal is a live-ball TO.
+    is_steal_flag = df.get("is_steal", 0).fillna(0).astype(int) == 1
+
+    sub_lower = subfam.astype(str).str.lower()
+    # Some feeds may explicitly label "live-ball" in text.
+    sub_live_flag = sub_lower.str.contains("live")
+
+    df["is_turnover_live"] = is_tov_family & (is_steal_flag | sub_live_flag)
+    df["is_turnover_dead"] = is_tov_family & ~df["is_turnover_live"]
 
     # --- Foul flavors ---
     is_foul_family = fam == "foul"
@@ -120,10 +120,20 @@ def annotate_events(df: pd.DataFrame) -> pd.DataFrame:
 
     # --- And-ones via qualifiers ---
     def _is_and_one_row(row: pd.Series) -> bool:
-        quals = row.get("qualifiers") or []
-        if isinstance(quals, str):
+        quals = row.get("qualifiers")
+        if not quals:
             return False
-        quals_lower = [q.lower() for q in quals]
+
+        # If it's a string (e.g., from CSV), just substring search.
+        if isinstance(quals, str):
+            return "andone" in quals.lower()
+
+        # Otherwise, assume it's iterable and normalize.
+        try:
+            quals_lower = [str(q).lower() for q in quals]
+        except TypeError:
+            return False
+
         return "andone" in quals_lower
 
     df["is_and_one"] = df.apply(_is_and_one_row, axis=1)

--- a/nba_parser/pbp.py
+++ b/nba_parser/pbp.py
@@ -29,10 +29,20 @@ class PbP:
         # done to handle PbP classes created from imported csv files versus
         # those that are created by nba_scraper that handles game_date as a
         # proper datetime dtype
+        # Handle both string and datetime-like game_date formats.
         if self.df["game_date"].dtypes == "O":
-            self.game_date = datetime.strptime(
-                pbp_df["game_date"].unique()[0], "%Y-%m-%d"
-            )
+            raw = str(pbp_df["game_date"].unique()[0])
+            parsed = None
+            for fmt in ("%Y-%m-%d", "%m/%d/%Y"):
+                try:
+                    parsed = datetime.strptime(raw, fmt)
+                    break
+                except ValueError:
+                    continue
+            if parsed is None:
+                # Fallback: let pandas try to infer.
+                parsed = pd.to_datetime(raw)
+            self.game_date = parsed
             self.df["game_date"] = pd.to_datetime(self.df["game_date"])
         else:
             self.game_date = pbp_df["game_date"].unique()[0]
@@ -1933,6 +1943,9 @@ class PbP:
             # Fallback when no events were parsed
             poss_df["points_for_offense"] = 0
             poss_df["points_for_defense"] = 0
+
+        # Backwards-compatibility: expose scoring in a single points column too.
+        poss_df["points_made"] = poss_df["points_for_offense"]
 
         return poss_df
 


### PR DESCRIPTION
## Summary
- mark steal turnovers as live-ball regardless of subfamily wording and handle string qualifiers when tagging and-ones
- add game_date parsing support for multiple formats and mirror possession scoring into points_made for compatibility

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bb9a26ef483288b5452c9f01ed6ef)