### PR TITLE
Handle assist fallback and expose RAPM points_made

### DIFF
--- a/nba_parser/box_glossary.py
+++ b/nba_parser/box_glossary.py
@@ -191,21 +191,32 @@ def accumulate_player_counts(df: pd.DataFrame) -> pd.DataFrame:
                 if row.get("is_fg_make"):
                     _increment_count(counts[key], f"{zone}_FGM")
 
+            # Assist handling:
+            # - Prefer explicit assist_id if present.
+            # - Fall back to player2_id on made shots for legacy pbp where
+            #   assists live in player2_id.
             assist_id = row.get("assist_id")
+            if (assist_id is None or pd.isna(assist_id) or assist_id == 0) and "player2_id" in row.index:
+                assist_id = row.get("player2_id")
+
             assisted = not (pd.isna(assist_id) or assist_id == 0)
-            if assisted:
-                _increment_count(counts[key], "FGM_AST", 1 if row.get("is_fg_make") else 0)
-                if row.get("is_three") and row.get("is_fg_make"):
+
+            # Only count assists on made field goals
+            if assisted and row.get("is_fg_make"):
+                # Shooter-level assisted makes
+                _increment_count(counts[key], "FGM_AST", 1.0)
+                if row.get("is_three"):
                     _increment_count(counts[key], "ThreePM_AST")
-                if zone and row.get("is_fg_make"):
+                if zone:
                     _increment_count(counts[key], f"{zone}_FGM_AST")
-                if assisted:
-                    ast_key = (game_id, row.get("team_id"), assist_id)
-                    _increment_count(counts[ast_key], "AST")
-                    if zone:
-                        _increment_count(counts[ast_key], f"AST_{zone}")
-                    if row.get("is_three"):
-                        _increment_count(counts[ast_key], "AST_3P")
+
+                # Passer-level AST counts by zone and 3P
+                ast_key = (game_id, row.get("team_id"), assist_id)
+                _increment_count(counts[ast_key], "AST")
+                if zone:
+                    _increment_count(counts[ast_key], f"AST_{zone}")
+                if row.get("is_three"):
+                    _increment_count(counts[ast_key], "AST_3P")
             else:
                 _increment_count(counts[key], "FGA_UNAST")
                 if row.get("is_fg_make"):

--- a/nba_parser/pbp.py
+++ b/nba_parser/pbp.py
@@ -1951,11 +1951,20 @@ class PbP:
 
     def rapm_possessions(self):
         """
-        method to extract out all the rapm possessions to be able to run a RAPM
-        regression on later
+        Extract out all the rapm possessions to be able to run a RAPM
+        regression on later.
+
+        Uses the event-level scoring computed by _build_possessions(), which
+        returns points_for_offense / points_for_defense for each possession.
+
+        For backward compatibility, this also exposes a points_made column
+        equal to points_for_offense.
         """
         pbp_df = self.df.copy()
         poss_df = self._build_possessions(pbp_df, include_event_agg=False)
+
+        if "points_for_offense" in poss_df.columns:
+            poss_df["points_made"] = poss_df["points_for_offense"]
 
         return poss_df
 


### PR DESCRIPTION
## Summary
- update assist counting to prefer assist_id while falling back to player2_id on made shots and only credit assists on makes
- ensure rapm_possessions surfaces points_made based on points_for_offense for backward compatibility

## Testing
- pytest test/test_unit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bbad417ec83288777a0a4c5e95f57)