### PR TITLE
Fix charge crediting and possession parsing

### DIFF
--- a/nba_parser/box_glossary.py
+++ b/nba_parser/box_glossary.py
@@ -268,6 +268,7 @@ def accumulate_player_counts(df: pd.DataFrame) -> pd.DataFrame:
                 _increment_count(counts[key], "TOV_Dead")
 
         if row.get("family") == "foul" and not pd.isna(player_id):
+            # Player 1 commits the foul
             _increment_count(counts[key], "PF")
             if row.get("is_loose_ball_foul"):
                 _increment_count(counts[key], "PF_Loose")
@@ -275,13 +276,17 @@ def accumulate_player_counts(df: pd.DataFrame) -> pd.DataFrame:
                 _increment_count(counts[key], "FLAGRANT")
             if row.get("is_technical"):
                 _increment_count(counts[key], "TECH")
-            if row.get("is_charge"):
-                _increment_count(counts[key], "CHRG")
+
             fouled = row.get("player2_id")
             fouled_team = row.get("player2_team_id")
             if fouled and not pd.isna(fouled) and fouled_team and not pd.isna(fouled_team):
                 foul_key = (game_id, fouled_team, fouled)
+                # Generic foul drawn
                 _increment_count(counts[foul_key], "PF_DRAWN")
+
+                # Charges drawn: subset of PF_DRAWN where the foul is a charge
+                if row.get("is_charge"):
+                    _increment_count(counts[foul_key], "CHRG")
 
         if row.get("is_block") == 1:
             blocker = row.get("player3_id")

--- a/nba_parser/pbp.py
+++ b/nba_parser/pbp.py
@@ -1064,7 +1064,7 @@ class PbP:
                                 df.loc[
                                     df.index[-1],
                                     [
-                                        "points_made_y",
+                                        "points_made",
                                         "home_team_abbrev",
                                         "event_team",
                                         "away_team_abbrev",
@@ -1126,7 +1126,7 @@ class PbP:
                                 df.loc[
                                     df.index[-1],
                                     [
-                                        "points_made_y",
+                                        "points_made",
                                         "home_team_abbrev",
                                         "event_team",
                                         "away_team_abbrev",
@@ -1189,7 +1189,7 @@ class PbP:
                                 df.loc[
                                     df.index[-1],
                                     [
-                                        "points_made_y",
+                                        "points_made",
                                         "home_team_abbrev",
                                         "event_team",
                                         "away_team_abbrev",
@@ -1252,7 +1252,7 @@ class PbP:
                                 df.loc[
                                     df.index[-1],
                                     [
-                                        "points_made_y",
+                                        "points_made",
                                         "home_team_abbrev",
                                         "event_team",
                                         "away_team_abbrev",
@@ -1316,7 +1316,7 @@ class PbP:
                             df.loc[
                                 df.index[-1],
                                 [
-                                    "points_made_y",
+                                    "points_made",
                                     "home_team_abbrev",
                                     "event_team",
                                     "away_team_abbrev",
@@ -1378,7 +1378,7 @@ class PbP:
                             df.loc[
                                 df.index[-1],
                                 [
-                                    "points_made_y",
+                                    "points_made",
                                     "home_team_abbrev",
                                     "event_team",
                                     "away_team_abbrev",
@@ -1443,25 +1443,22 @@ class PbP:
         """
 
         pbp_df = df.copy()
-        points_by_second = (
-            pbp_df.groupby(["game_id", "seconds_elapsed"])["points_made"]
-            .sum()
-            .reset_index()
-        )
-        pbp_df = pbp_df.merge(points_by_second, on=["game_id", "seconds_elapsed"])
 
         poss_index = pbp_df[(pbp_df.home_possession == 1) | (pbp_df.away_possession == 1)].index
         shift_dfs = []
         past_index = 0
 
         for i in poss_index:
-            shift_dfs.extend([pbp_df.iloc[past_index + 1 : i + 1, :].reset_index()])
+            # Slice events between possession markers, skipping empty segments
+            seg = pbp_df.iloc[past_index + 1 : i + 1, :].reset_index(drop=True)
+            if not seg.empty:
+                shift_dfs.append(seg)
             past_index = i
 
         parsed_possessions = self.parse_possessions(shift_dfs)
 
+        # If no possessions were detected, return an empty DataFrame
         if not parsed_possessions:
-            # No possessions detected; return an empty DataFrame so callers can handle gracefully.
             return pd.DataFrame()
 
         event_aggs = []


### PR DESCRIPTION
## Summary
- credit charges to the fouled defender as a subset of fouls drawn rather than the fouler
- simplify possession parsing by skipping empty segments and removing redundant points aggregation
- use event-level `points_made` consistently when building possessions

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bc9ba75308328a864be1b34e32ab5)