### PR TITLE
Improve annotate_events robustness

### DIFF
--- a/nba_parser/box_glossary.py
+++ b/nba_parser/box_glossary.py
@@ -56,9 +56,9 @@ def annotate_events(df: pd.DataFrame) -> pd.DataFrame:
 
     # --- Canonical family based on event_type_de, not API family ---
     if "event_type_de" in df.columns:
-        fam_src = df["event_type_de"]
+        fam_src = df["event_type_de"].fillna("")
     elif "family" in df.columns:
-        fam_src = df["family"]
+        fam_src = df["family"].fillna("")
     else:
         # If we truly have no event type info, fall back to an empty string series
         fam_src = pd.Series([""] * len(df), index=df.index)
@@ -139,7 +139,8 @@ def annotate_events(df: pd.DataFrame) -> pd.DataFrame:
 
         # If qualifiers come in as a string (e.g., from CSV), do a simple substring search.
         if isinstance(quals, str):
-            return "andone" in quals.lower()
+            q = quals.lower()
+            return ("andone" in q) or ("and1" in q) or ("and-one" in q)
 
         # Otherwise assume it's iterable and normalize each entry.
         try:
@@ -147,7 +148,7 @@ def annotate_events(df: pd.DataFrame) -> pd.DataFrame:
         except TypeError:
             return False
 
-        return "andone" in quals_lower
+        return any(s in q for q in quals_lower for s in ("andone", "and1", "and-one"))
 
     df["is_and_one"] = df.apply(_is_and_one_row, axis=1)
 

--- a/nba_parser/pbp.py
+++ b/nba_parser/pbp.py
@@ -1187,23 +1187,27 @@ class PbP:
                         df.loc[df.index[-1], "event_team"]
                         == df.loc[df.index[-1], "away_team_abbrev"]
                     ):
+                        # Defensive rebound by away team: offense was home team
+                        tail = df.loc[
+                            df.index[-1],
+                            [
+                                "points_made",
+                                "home_team_abbrev",
+                                "event_team",
+                                "away_team_abbrev",
+                                "home_team_id",
+                                "away_team_id",
+                                "game_id",
+                                "game_date",
+                                "season",
+                            ],
+                        ].copy()
+                        tail["event_team"] = tail["home_team_abbrev"]
+
                         row_df = pd.concat(
                             [
                                 df.loc[df.index[-1], player_cols],
-                                df.loc[
-                                    df.index[-1],
-                                    [
-                                        "points_made",
-                                        "home_team_abbrev",
-                                        "event_team",
-                                        "away_team_abbrev",
-                                        "home_team_id",
-                                        "away_team_id",
-                                        "game_id",
-                                        "game_date",
-                                        "season",
-                                    ],
-                                ],
+                                tail,
                             ]
                         )
 
@@ -1250,23 +1254,27 @@ class PbP:
                         df.loc[df.index[-1], "event_team"]
                         == df.loc[df.index[-1], "home_team_abbrev"]
                     ):
+                        # Defensive rebound by home team: offense was away team
+                        tail = df.loc[
+                            df.index[-1],
+                            [
+                                "points_made",
+                                "home_team_abbrev",
+                                "event_team",
+                                "away_team_abbrev",
+                                "home_team_id",
+                                "away_team_id",
+                                "game_id",
+                                "game_date",
+                                "season",
+                            ],
+                        ].copy()
+                        tail["event_team"] = tail["away_team_abbrev"]
+
                         row_df = pd.concat(
                             [
                                 df.loc[df.index[-1], player_cols],
-                                df.loc[
-                                    df.index[-1],
-                                    [
-                                        "points_made",
-                                        "home_team_abbrev",
-                                        "event_team",
-                                        "away_team_abbrev",
-                                        "home_team_id",
-                                        "away_team_id",
-                                        "game_id",
-                                        "game_date",
-                                        "season",
-                                    ],
-                                ],
+                                tail,
                             ]
                         )
 

--- a/nba_parser/pbp.py
+++ b/nba_parser/pbp.py
@@ -1058,25 +1058,28 @@ class PbP:
                         df.loc[df.index[-1], "event_team"]
                         == df.loc[df.index[-1], "home_team_abbrev"]
                     ):
-                        row_df = pd.concat(
+                        tail = df.loc[
+                            df.index[-1],
                             [
-                                df.loc[df.index[-1], player_cols],
-                                df.loc[
-                                    df.index[-1],
-                                    [
-                                        "points_made",
-                                        "home_team_abbrev",
-                                        "event_team",
-                                        "away_team_abbrev",
-                                        "home_team_id",
-                                        "away_team_id",
-                                        "game_id",
-                                        "game_date",
-                                        "season",
-                                    ],
-                                ],
-                            ]
-                        )
+                                "points_made",
+                                "home_team_abbrev",
+                                "event_team",
+                                "away_team_abbrev",
+                                "home_team_id",
+                                "away_team_id",
+                                "game_id",
+                                "game_date",
+                                "season",
+                            ],
+                        ].copy()
+                        # Defensive rebounds end the possession; the offensive
+                        # team is the opponent of the rebounder.
+                        tail["event_team"] = tail["home_team_abbrev"]
+
+                        row_df = pd.concat([
+                            df.loc[df.index[-1], player_cols],
+                            tail,
+                        ])
 
                         parsed_list.extend(
                             [
@@ -1120,25 +1123,26 @@ class PbP:
                         df.loc[df.index[-1], "event_team"]
                         == df.loc[df.index[-1], "away_team_abbrev"]
                     ):
-                        row_df = pd.concat(
+                        tail = df.loc[
+                            df.index[-1],
                             [
-                                df.loc[df.index[-1], player_cols],
-                                df.loc[
-                                    df.index[-1],
-                                    [
-                                        "points_made",
-                                        "home_team_abbrev",
-                                        "event_team",
-                                        "away_team_abbrev",
-                                        "home_team_id",
-                                        "away_team_id",
-                                        "game_id",
-                                        "game_date",
-                                        "season",
-                                    ],
-                                ],
-                            ]
-                        )
+                                "points_made",
+                                "home_team_abbrev",
+                                "event_team",
+                                "away_team_abbrev",
+                                "home_team_id",
+                                "away_team_id",
+                                "game_id",
+                                "game_date",
+                                "season",
+                            ],
+                        ].copy()
+                        tail["event_team"] = tail["away_team_abbrev"]
+
+                        row_df = pd.concat([
+                            df.loc[df.index[-1], player_cols],
+                            tail,
+                        ])
 
                         parsed_list.extend(
                             [
@@ -1486,15 +1490,26 @@ class PbP:
                 continue
 
             last_event = poss_events.iloc[-1]
-            off_abbrev = last_event.get("event_team")
+            last_team = last_event.get("event_team")
+            home_abbrev = last_event.get("home_team_abbrev")
+            away_abbrev = last_event.get("away_team_abbrev")
+
+            # Possessions end with a turnover or a defensive rebound. In the
+            # rebound case the offensive team is the opponent of the rebounding
+            # team, not the rebounder itself.
+            if last_event.get("event_type_de") == "rebound":
+                off_abbrev = away_abbrev if last_team == home_abbrev else home_abbrev
+            else:
+                off_abbrev = last_team
+
             off_team_id = (
                 last_event.get("home_team_id")
-                if off_abbrev == last_event.get("home_team_abbrev")
+                if off_abbrev == home_abbrev
                 else last_event.get("away_team_id")
             )
             def_team_id = (
                 last_event.get("away_team_id")
-                if off_abbrev == last_event.get("home_team_abbrev")
+                if off_abbrev == home_abbrev
                 else last_event.get("home_team_id")
             )
 


### PR DESCRIPTION
## Summary
- fill missing event_type_de/family values before canonicalizing family strings to avoid unintended 'nan' labels
- broaden and-one qualifier detection to recognize additional spelling variants
- ensure possessions ending in defensive rebounds attribute offensive totals to the shooting team rather than the rebounder

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bd16e765c83288644f515b141179f)