### PR TITLE
Add possession_after possession handling and strengthen event parsing

### DIFF
--- a/nba_parser/box_glossary.py
+++ b/nba_parser/box_glossary.py
@@ -3,8 +3,47 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import Optional, Dict, Any, List, Tuple
 
+import re
+
 import numpy as np
 import pandas as pd
+
+# Mapping for base positions to numeric slots.
+# 1=PG, 2=SG, 3=SF, 4=PF, 5=C. "G" and "F" are midpoints.
+_BASE_POS_NUM = {
+    "PG": 1.0,
+    "SG": 2.0,
+    "SF": 3.0,
+    "PF": 4.0,
+    "C": 5.0,
+    "G": 1.5,   # generic guard between PG/SG
+    "F": 3.5,   # generic forward between SF/PF
+}
+
+
+def position_to_num(pos: Any) -> float | None:
+    """
+    Convert a position string like 'PG', 'SG', 'G-F', 'F-C' into a numeric
+    encoding. Returns NaN for unknown/missing positions.
+
+    Rules:
+      - Single positions map via _BASE_POS_NUM.
+      - Hyphen/slash separated combos (e.g. 'G-F', 'SF/PF') average the
+        numeric values of each token that is recognized.
+    """
+    if not isinstance(pos, str) or not pos:
+        return np.nan
+
+    pos_str = pos.upper().replace(" ", "")
+    tokens = re.split(r"[-/]", pos_str)
+    vals = [
+        _BASE_POS_NUM[t]
+        for t in tokens
+        if t in _BASE_POS_NUM
+    ]
+    if not vals:
+        return np.nan
+    return float(np.mean(vals))
 
 ZONE_BINS: List[Tuple[float, float, str]] = [
     (0.0, 3.0, "0_3"),
@@ -47,6 +86,12 @@ def annotate_events(df: pd.DataFrame) -> pd.DataFrame:
     # --- Subfamily normalization ---
     if "subfamily_de" in df.columns:
         subfam = df["subfamily_de"].fillna("")
+    elif "event_sub_family" in df.columns:
+        df["subfamily_de"] = df["event_sub_family"].fillna("")
+        subfam = df["subfamily_de"]
+    elif "event_subfamily" in df.columns:
+        df["subfamily_de"] = df["event_subfamily"].fillna("")
+        subfam = df["subfamily_de"]
     elif "subfamily" in df.columns:
         df["subfamily_de"] = df["subfamily"].fillna("")
         subfam = df["subfamily_de"]
@@ -108,7 +153,15 @@ def annotate_events(df: pd.DataFrame) -> pd.DataFrame:
     df["is_ft_make"] = df["is_ft"] & (df["points_made"] > 0)
 
     # Three-pointers
-    df["is_three"] = df.get("is_three", 0).astype(bool)
+    if "is_three" in df.columns:
+        df["is_three"] = df["is_three"].fillna(0).astype(bool)
+    else:
+        # Fallback heuristic: treat long-distance FG attempts as 3s if distance is known.
+        dist = df.get("shot_distance")
+        if dist is not None:
+            df["is_three"] = (dist.astype(float) >= 23.0) & df["is_fg_attempt"]
+        else:
+            df["is_three"] = False
 
     # --- Turnover live/dead ---
     is_tov_family = fam == "turnover"
@@ -320,6 +373,18 @@ def accumulate_player_counts(df: pd.DataFrame) -> pd.DataFrame:
 
         subfamily = row.get("subfamily_de") or row.get("subfamily")
         goaltend_flag = isinstance(subfamily, str) and "goaltend" in subfamily.lower()
+
+        # CDN feeds may encode goaltends via qualifiers instead of subfamily.
+        if not goaltend_flag:
+            quals = row.get("qualifiers")
+            if isinstance(quals, str):
+                goaltend_flag = "goaltend" in quals.lower()
+            else:
+                try:
+                    goaltend_flag = any("goaltend" in str(q).lower() for q in quals)
+                except TypeError:
+                    pass
+
         if goaltend_flag:
             goaltend_player = row.get("player3_id") or row.get("player1_id")
             goaltend_team = row.get("player3_team_id") or row.get("player1_team_id")

--- a/nba_parser/pbp.py
+++ b/nba_parser/pbp.py
@@ -65,86 +65,121 @@ class PbP:
         # the _build_possessions() output as the canonical representation of
         # possessions. These columns are kept for backwards compatibility.
 
-        # calculating made shot possessions
-        self.df["home_possession"] = np.where(
-            (self.df.event_team == self.df.home_team_abbrev)
-            & (self.df.event_type_de == "shot"),
-            1,
-            0,
-        )
-        # calculating turnover possessions
-        self.df["home_possession"] = np.where(
-            (self.df.event_team == self.df.home_team_abbrev)
-            & (self.df.event_type_de == "turnover"),
-            1,
-            self.df["home_possession"],
-        )
-        # calculating defensive rebound possessions
-        self.df["home_possession"] = np.where(
-            (
-                (self.df.event_team == self.df.away_team_abbrev)
-                & (self.df.is_d_rebound == 1)
-            )
-            | (
-                (self.df.event_type_de == "rebound")
-                & (self.df.is_d_rebound == 0)
-                & (self.df.is_o_rebound == 0)
-                & (self.df.event_team == self.df.away_team_abbrev)
-                & (self.df.event_type_de.shift(1) != "free-throw")
-            ),
-            1,
-            self.df["home_possession"],
-        )
-        # calculating final free throw possessions
-        self.df["home_possession"] = np.where(
-            (self.df.event_team == self.df.home_team_abbrev)
-            & (
-                (self.df.homedescription.str.contains("Free Throw 2 of 2"))
-                | (self.df.homedescription.str.contains("Free Throw 3 of 3"))
-            ),
-            1,
-            self.df["home_possession"],
-        )
-        # calculating made shot possessions
-        self.df["away_possession"] = np.where(
-            (self.df.event_team == self.df.away_team_abbrev)
-            & (self.df.event_type_de == "shot"),
-            1,
-            0,
-        )
-        # calculating turnover possessions
-        self.df["away_possession"] = np.where(
-            (self.df.event_team == self.df.away_team_abbrev)
-            & (self.df.event_type_de == "turnover"),
-            1,
-            self.df["away_possession"],
-        )
-        # calculating defensive rebound possessions
-        self.df["away_possession"] = np.where(
-            (
+        # Prefer canonical possession_after when available (CDN + modern schema),
+        # fall back to legacy text-based heuristics otherwise.
+        if "possession_after" in self.df.columns:
+            # Start with zeros.
+            self.df["home_possession"] = 0
+            self.df["away_possession"] = 0
+
+            home_id = self.home_team_id
+            away_id = self.away_team_id
+
+            pos_raw = self.df["possession_after"]
+
+            # Normalize: treat only home/away IDs as valid possession owners.
+            # Forward-fill to cover sequences of events where possession doesn't change.
+            pos_team = pos_raw.where(pos_raw.isin([home_id, away_id]))
+            pos_team = pos_team.ffill()
+
+            # For any leading NaNs (pre-jump-ball) that are still NaN after ffill,
+            # backfill them with the first valid possession owner so those events
+            # belong to the first possession.
+            pos_team = pos_team.bfill()
+
+            # At this point, pos_team is constant over stretches where the same
+            # team has the ball. The end of each stretch is a possession boundary.
+            is_last_in_stretch = (pos_team != pos_team.shift(-1)) | pos_team.isna()
+
+            # Mark the final event of each possession for home vs away.
+            home_pos_idx = is_last_in_stretch & (pos_team == home_id)
+            away_pos_idx = is_last_in_stretch & (pos_team == away_id)
+
+            self.df.loc[home_pos_idx, "home_possession"] = 1
+            self.df.loc[away_pos_idx, "away_possession"] = 1
+
+        else:
+            # --- LEGACY HEURISTIC POSSESSION FLAGS (existing code path) ---
+            # calculating made shot possessions
+            self.df["home_possession"] = np.where(
                 (self.df.event_team == self.df.home_team_abbrev)
-                & (self.df.is_d_rebound == 1)
+                & (self.df.event_type_de == "shot"),
+                1,
+                0,
             )
-            | (
-                (self.df.event_type_de == "rebound")
-                & (self.df.is_d_rebound == 0)
-                & (self.df.is_o_rebound == 0)
-                & (self.df.event_team == self.df.home_team_abbrev)
-                & (self.df.event_type_de.shift(1) != "free-throw")
-            ),
-            1,
-            self.df["away_possession"],
-        )
-        # calculating final free throw possessions
-        self.df["away_possession"] = np.where(
-            (self.df.event_team == self.df.away_team_abbrev)
-            & (
-                (self.df.visitordescription.str.contains("Free Throw 2 of 2"))
-                | (self.df.visitordescription.str.contains("Free Throw 3 of 3"))
-            ),
-            1,
-            self.df["away_possession"],
-        )
+            # calculating turnover possessions
+            self.df["home_possession"] = np.where(
+                (self.df.event_team == self.df.home_team_abbrev)
+                & (self.df.event_type_de == "turnover"),
+                1,
+                self.df["home_possession"],
+            )
+            # calculating defensive rebound possessions
+            self.df["home_possession"] = np.where(
+                (
+                    (self.df.event_team == self.df.away_team_abbrev)
+                    & (self.df.is_d_rebound == 1)
+                )
+                | (
+                    (self.df.event_type_de == "rebound")
+                    & (self.df.is_d_rebound == 0)
+                    & (self.df.is_o_rebound == 0)
+                    & (self.df.event_team == self.df.away_team_abbrev)
+                    & (self.df.event_type_de.shift(1) != "free-throw")
+                ),
+                1,
+                self.df["home_possession"],
+            )
+            # calculating final free throw possessions
+            self.df["home_possession"] = np.where(
+                (self.df.event_team == self.df.home_team_abbrev)
+                & (
+                    (self.df.homedescription.str.contains("Free Throw 2 of 2"))
+                    | (self.df.homedescription.str.contains("Free Throw 3 of 3"))
+                ),
+                1,
+                self.df["home_possession"],
+            )
+            # calculating made shot possessions
+            self.df["away_possession"] = np.where(
+                (self.df.event_team == self.df.away_team_abbrev)
+                & (self.df.event_type_de == "shot"),
+                1,
+                0,
+            )
+            # calculating turnover possessions
+            self.df["away_possession"] = np.where(
+                (self.df.event_team == self.df.away_team_abbrev)
+                & (self.df.event_type_de == "turnover"),
+                1,
+                self.df["away_possession"],
+            )
+            # calculating defensive rebound possessions
+            self.df["away_possession"] = np.where(
+                (
+                    (self.df.event_team == self.df.home_team_abbrev)
+                    & (self.df.is_d_rebound == 1)
+                )
+                | (
+                    (self.df.event_type_de == "rebound")
+                    & (self.df.is_d_rebound == 0)
+                    & (self.df.is_o_rebound == 0)
+                    & (self.df.event_team == self.df.home_team_abbrev)
+                    & (self.df.event_type_de.shift(1) != "free-throw")
+                ),
+                1,
+                self.df["away_possession"],
+            )
+            # calculating final free throw possessions
+            self.df["away_possession"] = np.where(
+                (self.df.event_team == self.df.away_team_abbrev)
+                & (
+                    (self.df.visitordescription.str.contains("Free Throw 2 of 2"))
+                    | (self.df.visitordescription.str.contains("Free Throw 3 of 3"))
+                ),
+                1,
+                self.df["away_possession"],
+            )
 
     def _point_calc_player(self):
         """


### PR DESCRIPTION
## Summary
- prefer possession_after for marking possession boundaries while keeping legacy heuristics as fallback
- improve event annotation robustness for subfamily naming, three-point inference, and goaltend qualifiers
- add position-to-numeric helper for downstream player box support

## Testing
- python -m pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bd268498c832895608c31d4f07ab6)