### PR TITLE
Handle missing shot zones and ignore zero team totals

### DIFF
--- a/nba_parser/box_glossary.py
+++ b/nba_parser/box_glossary.py
@@ -28,14 +28,18 @@ def classify_shot_zone(shot_distance: float | None, area: str | None) -> Optiona
         else:
             return None
 
-    if area:
-        area_lower = area.lower()
-        if "restricted" in area_lower:
-            return "0_3"
-        if "paint" in area_lower:
-            return "4_9"
-        if "mid-range" in area_lower:
-            return None
+    # Some CDN datasets omit the shot area entirely or encode it as NaN/float.
+    if area is None or pd.isna(area):
+        return None
+
+    area_str = area if isinstance(area, str) else str(area)
+    area_lower = area_str.lower()
+    if "restricted" in area_lower:
+        return "0_3"
+    if "paint" in area_lower:
+        return "4_9"
+    if "mid-range" in area_lower:
+        return None
     return None
 
 

--- a/nba_parser/pbp.py
+++ b/nba_parser/pbp.py
@@ -817,8 +817,12 @@ class PbP:
             True,
             False,
         )
+        valid_team_rows = self.df[
+            self.df["player1_team_id"].notna() & (self.df["player1_team_id"] != 0)
+        ]
+
         teams_df = (
-            self.df.groupby(["player1_team_id", "game_id"])[
+            valid_team_rows.groupby(["player1_team_id", "game_id"])[
                 [
                     "points_made",
                     "is_three",


### PR DESCRIPTION
## Summary
- handle missing or non-string shot area values when classifying shot zones
- filter out events with null or zero team IDs when computing team point totals

## Testing
- pytest -q
- python - <<'PY'
import pandas as pd
import nba_parser as npar
pbp_df = pd.read_csv('test/0021900151_cdn.csv')
pbp = npar.PbP(pbp_df)
box = pbp.player_box_glossary()
assert not box.empty
assert ((box["POSS_OFF"] + box["POSS_DEF"]) == box["POSS"]).all()
team_points = pbp._point_calc_team()[["team_id", "points_for"]]
team_points_map = dict(zip(team_points["team_id"], team_points["points_for"]))
for tid, pts_for in team_points_map.items():
    on_court_for = box.loc[box["team_id"] == tid, "OnCourt_Team_Points"].sum()
    assert abs(on_court_for - pts_for * 5) < 1e-6
PY

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bd2fbe6248328a6170e2b08041fad)