### PR TITLE
Harden PbP validation and enrich player metadata handling

### DIFF
--- a/nba_parser/box_glossary.py
+++ b/nba_parser/box_glossary.py
@@ -111,11 +111,34 @@ def annotate_events(df: pd.DataFrame) -> pd.DataFrame:
     fam = fam_src.astype(str).str.lower().str.replace("-", "_", regex=False)
     df["family"] = fam
 
-    # --- Event team id ---
-    if "team_id" not in df.columns:
+    # --- Event team id (robust normalization) ---
+    if "team_id" in df.columns:
+        team_id = df["team_id"].copy()
+        # Identify rows where team_id is present but invalid (NaN or 0)
+        mask_missing = team_id.isna() | (team_id == 0)
+        if mask_missing.any():
+            event_team = df.get("event_team")
+            if event_team is None:
+                event_team = df.get("team_tricode")
+            if event_team is None:
+                event_team = pd.Series([None] * len(df), index=df.index)
+
+            filled = np.where(
+                event_team == df.get("home_team_abbrev"),
+                df.get("home_team_id"),
+                np.where(
+                    event_team == df.get("away_team_abbrev"),
+                    df.get("away_team_id"),
+                    np.nan,
+                ),
+            )
+            # Apply the fix only to the invalid rows
+            team_id[mask_missing] = filled[mask_missing]
+        df["team_id"] = team_id
+    else:
+        # Fallback for when the column doesn't exist at all
         event_team = df.get("event_team")
         if event_team is None:
-            # Some feeds may expose team code as team_tricode instead.
             event_team = df.get("team_tricode")
         if event_team is None:
             event_team = pd.Series([None] * len(df), index=df.index)
@@ -123,11 +146,7 @@ def annotate_events(df: pd.DataFrame) -> pd.DataFrame:
         df["team_id"] = np.where(
             event_team == df.get("home_team_abbrev"),
             df.get("home_team_id"),
-            np.where(
-                event_team == df.get("away_team_abbrev"),
-                df.get("away_team_id"),
-                np.nan,
-            ),
+            np.where(event_team == df.get("away_team_abbrev"), df.get("away_team_id"), np.nan),
         )
 
     # --- Ensure event-level points_made exists ---
@@ -167,7 +186,10 @@ def annotate_events(df: pd.DataFrame) -> pd.DataFrame:
     is_tov_family = fam == "turnover"
 
     # Anything recorded as a steal is a live-ball turnover.
-    is_steal_flag = df.get("is_steal", 0).fillna(0).astype(int) == 1
+    is_steal_raw = df.get("is_steal")
+    if is_steal_raw is None:
+        is_steal_raw = pd.Series([0] * len(df), index=df.index)
+    is_steal_flag = is_steal_raw.fillna(0).astype(int) == 1
 
     sub_lower = subfam.astype(str).str.lower()
     # Some feeds may explicitly label "live-ball" in text.

--- a/nba_parser/pbp.py
+++ b/nba_parser/pbp.py
@@ -27,6 +27,13 @@ class PbP:
 
     def __init__(self, pbp_df):
         self.df = pbp_df
+
+        # Enforce single-game input
+        game_ids = self.df["game_id"].unique()
+        if len(game_ids) != 1:
+            raise ValueError(
+                f"PbP expects a single-game DataFrame, but found game_ids={game_ids}"
+            )
         self.home_team = pbp_df["home_team_abbrev"].unique()[0]
         self.away_team = pbp_df["away_team_abbrev"].unique()[0]
         self.home_team_id = pbp_df["home_team_id"].unique()[0]
@@ -1682,6 +1689,54 @@ class PbP:
         poss_df = self._build_possessions(pbp_df, include_event_agg=True)
         return poss_df
 
+    def _compute_starters(self) -> pd.DataFrame:
+        """
+        Return a DataFrame with one row per (game_id, team_id, player_id)
+        marking whether the player started the game (Starts = 1).
+
+        Assumes this PbP instance is a single game.
+        """
+        df = self.df.copy()
+
+        # Sort by game clock so we consistently pick the earliest event
+        sort_cols = [c for c in ["period", "seconds_elapsed", "eventnum"] if c in df.columns]
+        if sort_cols:
+            df = df.sort_values(sort_cols)
+
+        lineup_cols = [
+            *(f"home_player_{i}_id" for i in range(1, 6)),
+            *(f"away_player_{i}_id" for i in range(1, 6)),
+        ]
+
+        mask = pd.Series(True, index=df.index)
+        for col in lineup_cols:
+            if col in df.columns:
+                mask &= df[col].notna() & (df[col] != 0)
+
+        lineup_df = df[mask] if not df.empty else df
+        first_row = lineup_df.iloc[0] if not lineup_df.empty else df.iloc[0]
+
+        home_ids = [first_row.get(f"home_player_{i}_id") for i in range(1, 6)]
+        away_ids = [first_row.get(f"away_player_{i}_id") for i in range(1, 6)]
+
+        starters = []
+        game_id = first_row.get("game_id")
+        home_team_id = first_row.get("home_team_id")
+        away_team_id = first_row.get("away_team_id")
+
+        for pid in home_ids:
+            if pid and pid != 0 and not pd.isna(pid):
+                starters.append(
+                    {"game_id": game_id, "team_id": home_team_id, "player_id": int(pid), "Starts": 1}
+                )
+        for pid in away_ids:
+            if pid and pid != 0 and not pd.isna(pid):
+                starters.append(
+                    {"game_id": game_id, "team_id": away_team_id, "player_id": int(pid), "Starts": 1}
+                )
+
+        return pd.DataFrame(starters)
+
     def player_box_glossary(
         self,
         player_meta: pd.DataFrame | None = None,
@@ -1708,14 +1763,48 @@ class PbP:
         counts_df = accumulate_player_counts(df)
         exposures_df = compute_on_court_exposures(self, df)
 
+        # Defensively filter player_meta to the current season to avoid duplicate rows
+        pm = player_meta
+        if pm is not None and not pm.empty:
+            pm = pm.copy()
+            # If player_meta includes a 'season' or 'Year' column, trim to this game's season
+            if "season" in pm.columns:
+                pm = pm[pm["season"] == self.season]
+            elif "Year" in pm.columns:
+                pm = pm[pm["Year"] == self.season]
+
+            # Ensure unique row per player identifier
+            if "NbaDotComID" in pm.columns:
+                pm = pm.drop_duplicates(subset=["NbaDotComID"])
+            elif "player_id" in pm.columns:
+                pm = pm.drop_duplicates(subset=["player_id"])
+
         box_df = build_player_box(
             df=df,
             counts_df=counts_df,
             exposures_df=exposures_df,
-            player_meta=player_meta,
+            player_meta=pm,
             game_meta=game_meta,
             pbg_stats=self.playerbygamestats()
         )
+
+        # Normalize potential merge artifacts from player_meta
+        if "player_id_x" in box_df.columns:
+            box_df["player_id"] = box_df["player_id_x"]
+            box_df.drop(columns=[c for c in ["player_id_x", "player_id_y"] if c in box_df.columns], inplace=True)
+
+        # Fill Starts from starting lineups
+        starters_df = self._compute_starters()
+        if not starters_df.empty:
+            # Preserve original Starts column if it exists, then merge
+            if "Starts" in box_df.columns:
+                box_df.rename(columns={"Starts": "Starts_x"}, inplace=True)
+            box_df = box_df.merge(
+                starters_df, on=["game_id", "team_id", "player_id"], how="left"
+            )
+            # Coalesce merged 'Starts' with original, fill NaNs with 0
+            box_df["Starts"] = box_df["Starts"].fillna(box_df.get("Starts_x", 0)).fillna(0).astype(int)
+            box_df.drop(columns=[c for c in box_df.columns if c.endswith("_x") or c == 'Starts_y'], inplace=True)
 
         # Sanity check: on-court points must match team totals.
         self._check_on_court_points_consistency(box_df)

--- a/test/test_unit/test_player_box_glossary.py
+++ b/test/test_unit/test_player_box_glossary.py
@@ -53,3 +53,36 @@ def test_player_box_glossary_basics():
     )
     for col in ["fgm", "fga", "tpm", "tpa", "ftm", "fta", "points"]:
         assert (merged[col] == merged[f"{col}_old"]).all()
+
+
+def test_player_box_glossary_cdn_invariants():
+    """
+    Validates possession and exposure logic against a CDN-era game file,
+    ensuring key invariants (minutes and on-court points) hold true.
+    """
+    pbp_df = pd.read_csv("test/21900151.csv")
+    pbp_df["season"] = 2020
+    pbp = PbP(pbp_df)
+
+    box = pbp.player_box_glossary()
+
+    # 1. Validate Minutes Invariant
+    team_minutes = box.groupby("team_id")["Minutes"].sum()
+    game_minutes = pbp.df["seconds_elapsed"].max() / 60.0
+    # A small tolerance is needed for floating point comparisons
+    for _, minutes in team_minutes.items():
+        assert abs(minutes - game_minutes * 5) < 1.0
+
+    # 2. Validate On-Court Points Invariant
+    team_points = pbp._point_calc_team()[["team_id", "points_for"]]
+    team_points_map = dict(zip(team_points["team_id"], team_points["points_for"]))
+
+    for team_id, pts_for in team_points_map.items():
+        # Check points scored by the player's team while they were on court
+        team_total_for = box.loc[box["team_id"] == team_id, "OnCourt_Team_Points"].sum()
+        assert abs(team_total_for - pts_for * 5) < 1e-6
+
+        # Check points scored by the opponent while they were on court
+        opp_points = sum(p for t, p in team_points_map.items() if t != team_id)
+        team_total_against = box.loc[box["team_id"] == team_id, "OnCourt_Opp_Points"].sum()
+        assert abs(team_total_against - opp_points * 5) < 1e-6

--- a/test/test_unit/test_robustness_and_metadata.py
+++ b/test/test_unit/test_robustness_and_metadata.py
@@ -1,0 +1,85 @@
+import pandas as pd
+import numpy as np
+import pytest
+from nba_parser import PbP
+from nba_parser.box_glossary import annotate_events
+
+
+@pytest.fixture(scope="module")
+def pbp_v2_game():
+    """Provides a parsed PbP object for a V2 game."""
+    pbp_df = pd.read_csv("test/20700233.csv")
+    pbp_df["season"] = 2008
+    return PbP(pbp_df)
+
+
+def test_pbp_enforces_single_game():
+    """Validates Change 1: PbP class raises ValueError for multi-game DFs."""
+    multi_game_df = pd.DataFrame({
+        "game_id": ["001", "002"],
+        "home_team_abbrev": ["A", "C"],
+        "away_team_abbrev": ["B", "D"],
+        "home_team_id": [1, 3],
+        "away_team_id": [2, 4],
+        "season": [2024, 2024],
+        "game_date": ["2024-01-01", "2024-01-02"],
+        "scoremargin": ["0", "0"],
+    })
+    with pytest.raises(ValueError, match="expects a single-game DataFrame"):
+        PbP(multi_game_df)
+
+
+def test_robust_team_id_normalization():
+    """Validates Change 2: annotate_events correctly fills missing/zero team_id."""
+    df = pd.DataFrame({
+        "team_id": [1, 0, np.nan],  # One correct, one zero, one NaN
+        "event_team": ["HOME", "AWAY", "HOME"],
+        "home_team_abbrev": ["HOME", "HOME", "HOME"],
+        "away_team_abbrev": ["AWAY", "AWAY", "AWAY"],
+        "home_team_id": [1, 1, 1],
+        "away_team_id": [2, 2, 2],
+    })
+
+    annotated = annotate_events(df)
+
+    assert annotated["team_id"].tolist() == [1.0, 2.0, 1.0]
+
+
+def test_compute_starters(pbp_v2_game):
+    """Validates Change 3: Starters are correctly identified."""
+    box = pbp_v2_game.player_box_glossary()
+
+    # From the 20700233.csv file, we can identify the starters
+    denver_starters = {2546, 2030, 948, 947, 1853}
+    lac_starters = {1739, 1501, 2549, 1894, 1510}
+    all_starters = denver_starters.union(lac_starters)
+
+    starter_rows = box[box["Starts"] == 1]
+    non_starter_rows = box[box["Starts"] == 0]
+
+    assert len(starter_rows) == 10
+    assert set(starter_rows["player_id"]) == all_starters
+    # Ensure no non-starters were incorrectly flagged
+    assert not any(pid in all_starters for pid in non_starter_rows["player_id"])
+
+
+def test_player_meta_deduplication(pbp_v2_game):
+    """Validates Change 4: Multi-season player_meta is correctly filtered."""
+    # Player 947 has rows for two seasons
+    multi_season_meta = pd.DataFrame({
+        "player_id": [947, 947, 1894],
+        "season": [2008, 2009, 2008],
+        "FullName": ["Allen Iverson (08)", "Allen Iverson (09)", "Cuttino Mobley"],
+        "Age": [32, 33, 32]
+    })
+
+    # The game's season is 2008
+    box = pbp_v2_game.player_box_glossary(player_meta=multi_season_meta)
+
+    ai_row = box[box["player_id"] == 947]
+
+    # Check that we only have one row for the player
+    assert len(ai_row) == 1
+    # Check that the correct season's data was used
+    assert ai_row["FullName"].iloc[0] == "Allen Iverson (08)"
+    assert ai_row["Age"].iloc[0] == 32


### PR DESCRIPTION
## Summary
- enforce single-game PbP initialization, add starter inference, and filter player metadata to the current season
- strengthen team_id normalization in annotate_events for missing or zero values
- add robustness tests covering PbP validation, starter detection, player metadata filtering, and CDN invariants

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691be3291b588328858d652348bd5e34)