### PR TITLE
Handle rebound opportunities and rate fixes

### DIFF
--- a/nba_parser/box_glossary.py
+++ b/nba_parser/box_glossary.py
@@ -155,6 +155,8 @@ def annotate_events(df: pd.DataFrame) -> pd.DataFrame:
     fam = fam_src.astype(str).str.lower().str.replace("-", "_", regex=False)
     df["family"] = fam
 
+    sub_lower = subfam.astype(str).str.lower()
+
     # --- Event team id (robust normalization) ---
     if "home_team_id" not in df.columns:
         df["home_team_id"] = np.nan
@@ -225,6 +227,22 @@ def annotate_events(df: pd.DataFrame) -> pd.DataFrame:
     df["is_ft"] = fam == "free_throw"
     df["is_ft_make"] = df["is_ft"] & (df["points_made"] > 0)
 
+    # --- Identify the last FT attempt of a trip (for rebound opportunities) ---
+    if "ft_n" in df.columns and "ft_m" in df.columns:
+        try:
+            ft_n = df["ft_n"].fillna(0).astype(int)
+            ft_m = df["ft_m"].fillna(0).astype(int)
+            df["is_last_ft"] = (ft_n == ft_m) & (ft_n > 0)
+        except (ValueError, TypeError):
+            df["is_last_ft"] = False
+    else:
+        # Fallback heuristic if ft_n/ft_m are not available
+        df["is_last_ft"] = df["is_ft"] & (
+            sub_lower.str.contains("1 of 1")
+            | sub_lower.str.contains("2 of 2")
+            | sub_lower.str.contains("3 of 3")
+        )
+
     if "is_o_rebound" not in df.columns:
         df["is_o_rebound"] = 0
     if "is_d_rebound" not in df.columns:
@@ -250,7 +268,6 @@ def annotate_events(df: pd.DataFrame) -> pd.DataFrame:
         steal_col = pd.Series([0] * len(df), index=df.index)
     is_steal_flag = steal_col.fillna(0).astype(int) == 1
 
-    sub_lower = subfam.astype(str).str.lower()
     # Some feeds may explicitly label "live-ball" in text.
     sub_live_flag = sub_lower.str.contains("live")
 
@@ -506,8 +523,14 @@ def compute_on_court_exposures(pbp: "PbP", df: pd.DataFrame) -> pd.DataFrame:
                     key = (row.get("game_id"), block_team, pid)
                     _increment_count(exposures[key], "TM_BLK_OnCourt")
 
-        # Treat any missed FG attempt as an OREB/DREB opportunity, using the normalized flag.
-        if row.get("is_fg_attempt") and not bool(row.get("is_fg_make")):
+        is_missed_fg = row.get("is_fg_attempt") and not bool(row.get("is_fg_make"))
+        is_missed_last_ft = (
+            row.get("is_ft")
+            and not bool(row.get("is_ft_make"))
+            and row.get("is_last_ft", False)
+        )
+
+        if is_missed_fg or is_missed_last_ft:
             shoot_team = row.get("team_id")
             home_on = home_ids
             away_on = away_ids
@@ -516,7 +539,9 @@ def compute_on_court_exposures(pbp: "PbP", df: pd.DataFrame) -> pd.DataFrame:
             for pid in (home_on if shoot_team == row.get("home_team_id") else away_on):
                 if pid and pid != 0:
                     key = (row.get("game_id"), shoot_team, pid)
-                    _increment_count(exposures[key], "OnCourt_For_OREB_FGA")
+                    if is_missed_fg:
+                        _increment_count(exposures[key], "OnCourt_For_OREB_FGA")
+                    _increment_count(exposures[key], "OnCourt_For_OREB_Total")
 
             # Defensive rebound opportunities for the defending team
             opp_team = (
@@ -527,7 +552,9 @@ def compute_on_court_exposures(pbp: "PbP", df: pd.DataFrame) -> pd.DataFrame:
             for pid in (away_on if shoot_team == row.get("home_team_id") else home_on):
                 if pid and pid != 0:
                     key = (row.get("game_id"), opp_team, pid)
-                    _increment_count(exposures[key], "OnCourt_For_DREB_FGA")
+                    if is_missed_fg:
+                        _increment_count(exposures[key], "OnCourt_For_DREB_FGA")
+                    _increment_count(exposures[key], "OnCourt_For_DREB_Total")
 
     poss_df = pbp._build_possessions(df, include_event_agg=True)
     for _, poss in poss_df.iterrows():
@@ -563,6 +590,7 @@ def compute_on_court_exposures(pbp: "PbP", df: pd.DataFrame) -> pd.DataFrame:
                 _increment_count(exposures[key], "OnCourt_Team_Points", def_points)
                 _increment_count(exposures[key], "OnCourt_Opp_3p_Att", poss.get("off_team_3PA", 0))
                 _increment_count(exposures[key], "OnCourt_Opp_3p_Made", poss.get("off_team_3PM", 0))
+                _increment_count(exposures[key], "OnCourt_Opp_2p_Att", poss.get("off_team_2PA", 0))
                 _increment_count(exposures[key], "OnCourt_Opp_FT_Att", poss.get("off_team_FTA", 0))
                 _increment_count(exposures[key], "OnCourt_Opp_FT_Made", poss.get("off_team_FTM", 0))
                 _increment_count(exposures[key], "OnCourt_Opp_FGA", poss.get("off_team_FGA", 0))
@@ -588,8 +616,11 @@ def compute_on_court_exposures(pbp: "PbP", df: pd.DataFrame) -> pd.DataFrame:
         vals.setdefault("OnCourt_Opp_3p_Att", 0)
         vals.setdefault("OnCourt_Opp_FT_Made", 0)
         vals.setdefault("OnCourt_Opp_FT_Att", 0)
+        vals.setdefault("OnCourt_For_OREB_Total", 0)
+        vals.setdefault("OnCourt_For_DREB_Total", 0)
         vals.setdefault("OnCourt_For_OREB_FGA", 0)
         vals.setdefault("OnCourt_For_DREB_FGA", 0)
+        vals.setdefault("OnCourt_Opp_2p_Att", 0)
         vals.setdefault("TM_BLK_OnCourt", 0)
         vals.setdefault("OnCourt_Opp_FGM", 0)
         vals.setdefault("OnCourt_Opp_FGA", 0)
@@ -720,11 +751,28 @@ def build_player_box(
     merged["FTR_Att"] = np.where(merged["FGA"] > 0, merged["FTA"] / merged["FGA"], 0)
     merged["FTR_Made"] = np.where(merged["FGA"] > 0, merged["FTM"] / merged["FGA"], 0)
 
-    merged["ORBpct"] = np.where(merged["OnCourt_For_OREB_FGA"] > 0, merged.get("OREB", 0) / merged["OnCourt_For_OREB_FGA"], 0)
-    merged["DRBpct"] = np.where(merged["OnCourt_For_DREB_FGA"] > 0, merged.get("DREB", 0) / merged["OnCourt_For_DREB_FGA"], 0)
+    merged["ORBpct"] = np.where(
+        merged["OnCourt_For_OREB_Total"] > 0,
+        merged.get("OREB", 0) / merged["OnCourt_For_OREB_Total"],
+        0,
+    )
+    merged["DRBpct"] = np.where(
+        merged["OnCourt_For_DREB_Total"] > 0,
+        merged.get("DREB", 0) / merged["OnCourt_For_DREB_Total"],
+        0,
+    )
 
-    merged["ASTpct"] = np.where(merged["OnCourt_Team_FGM"] > 0, merged.get("AST", 0) / merged["OnCourt_Team_FGM"], 0)
-    merged["BLKPct"] = np.where(merged["OnCourt_Opp_FGA"] > 0, merged.get("BLK", 0) / merged["OnCourt_Opp_FGA"], 0)
+    teammate_fgm = merged["OnCourt_Team_FGM"] - merged.get("FGM", 0)
+    merged["ASTpct"] = np.where(
+        teammate_fgm > 0,
+        merged.get("AST", 0) / teammate_fgm,
+        0.0,
+    )
+    merged["BLKPct"] = np.where(
+        merged.get("OnCourt_Opp_2p_Att", 0) > 0,
+        merged.get("BLK", 0) / merged["OnCourt_Opp_2p_Att"],
+        0.0,
+    )
     merged["STLpct"] = np.where(merged["POSS_DEF"] > 0, merged.get("STL", 0) / merged["POSS_DEF"], 0)
     merged["TOVpct"] = np.where(merged["PossessionsUsed"] > 0, merged.get("TOV", 0) / merged["PossessionsUsed"], 0)
 

--- a/nba_parser/pbp.py
+++ b/nba_parser/pbp.py
@@ -1521,12 +1521,14 @@ class PbP:
                         "off_team_FGM": 0,
                         "off_team_3PA": 0,
                         "off_team_3PM": 0,
+                        "off_team_2PA": 0,
                         "off_team_FTA": 0,
                         "off_team_FTM": 0,
                         "def_team_FGA": 0,
                         "def_team_FGM": 0,
                         "def_team_3PA": 0,
                         "def_team_3PM": 0,
+                        "def_team_2PA": 0,
                         "def_team_FTA": 0,
                         "def_team_FTM": 0,
                         "points_for_offense": 0,
@@ -1592,6 +1594,10 @@ class PbP:
                 poss_events.loc[off_mask, "is_fg_make"].astype(bool)
                 & poss_events.loc[off_mask, "is_three"].astype(bool)
             )
+            off_2pa_mask = (
+                poss_events.loc[off_mask, "is_fg_attempt"].astype(bool)
+                & ~poss_events.loc[off_mask, "is_three"].astype(bool)
+            )
 
             def_fga = poss_events.loc[def_mask, "is_fg_attempt"].sum()
             def_fgm = poss_events.loc[def_mask, "is_fg_make"].sum()
@@ -1602,6 +1608,10 @@ class PbP:
             def_3pm_mask = (
                 poss_events.loc[def_mask, "is_fg_make"].astype(bool)
                 & poss_events.loc[def_mask, "is_three"].astype(bool)
+            )
+            def_2pa_mask = (
+                poss_events.loc[def_mask, "is_fg_attempt"].astype(bool)
+                & ~poss_events.loc[def_mask, "is_three"].astype(bool)
             )
 
             off_points = poss_events.loc[off_mask, "points_made"].sum()
@@ -1617,12 +1627,14 @@ class PbP:
                     "off_team_FGM": off_fgm,
                     "off_team_3PA": off_3pa_mask.sum(),
                     "off_team_3PM": off_3pm_mask.sum(),
+                    "off_team_2PA": off_2pa_mask.sum(),
                     "off_team_FTA": poss_events.loc[off_mask, "is_ft"].sum(),
                     "off_team_FTM": poss_events.loc[off_mask, "is_ft_make"].sum(),
                     "def_team_FGA": def_fga,
                     "def_team_FGM": def_fgm,
                     "def_team_3PA": def_3pa_mask.sum(),
                     "def_team_3PM": def_3pm_mask.sum(),
+                    "def_team_2PA": def_2pa_mask.sum(),
                     "def_team_FTA": poss_events.loc[def_mask, "is_ft"].sum(),
                     "def_team_FTM": poss_events.loc[def_mask, "is_ft_make"].sum(),
                     "points_for_offense": off_points,
@@ -1650,12 +1662,14 @@ class PbP:
                     "off_team_FGM",
                     "off_team_3PA",
                     "off_team_3PM",
+                    "off_team_2PA",
                     "off_team_FTA",
                     "off_team_FTM",
                     "def_team_FGA",
                     "def_team_FGM",
                     "def_team_3PA",
                     "def_team_3PM",
+                    "def_team_2PA",
                     "def_team_FTA",
                     "def_team_FTM",
                 ]:


### PR DESCRIPTION
## Summary
- flag the last free throw in a trip to properly capture rebound opportunities
- include missed final free throws and opponent 2-point attempts in on-court exposure tracking
- correct offensive/defensive rebound, assist, and block percentage formulas

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bf13a75e88328a5b59b613f6073d4)