### PR TITLE
Improve possession handling and team totals recalculation

### DIFF
--- a/nba_parser/box_glossary.py
+++ b/nba_parser/box_glossary.py
@@ -10,14 +10,14 @@ import pandas as pd
 
 # Mapping for base positions to numeric slots.
 # 1=PG, 2=SG, 3=SF, 4=PF, 5=C. "G" and "F" are midpoints.
-_BASE_POS_NUM = {
+_BASE_POS_NUM: Dict[str, float] = {
     "PG": 1.0,
     "SG": 2.0,
     "SF": 3.0,
     "PF": 4.0,
     "C": 5.0,
-    "G": 1.5,   # generic guard between PG/SG
-    "F": 3.5,   # generic forward between SF/PF
+    "G": 1.5,  # generic guard between PG/SG
+    "F": 3.5,  # generic forward between SF/PF
 }
 
 
@@ -39,6 +39,7 @@ def position_to_num(pos: Any) -> float | None:
         return np.nan
     return float(np.mean(vals))
 
+
 ZONE_BINS: List[Tuple[float, float, str]] = [
     (0.0, 3.0, "0_3"),
     (3.0, 9.0, "4_9"),
@@ -48,6 +49,10 @@ ZONE_BINS: List[Tuple[float, float, str]] = [
 
 
 def classify_shot_zone(shot_distance: float | None, area: str | None) -> Optional[str]:
+    """
+    Backwards‑compatible single‑shot classifier (kept for any call sites that
+    still use it directly). The pipeline should prefer _vectorized_shot_zone.
+    """
     if shot_distance is not None and not pd.isna(shot_distance):
         d = float(shot_distance)
         for lower, upper, label in ZONE_BINS:
@@ -121,6 +126,7 @@ def annotate_events(df: pd.DataFrame) -> pd.DataFrame:
     # Preserve original upstream family (e.g., "2pt", "3pt") for debugging.
     if "family" in df.columns and "family_raw" not in df.columns:
         df["family_raw"] = df["family"]
+
     # --- Subfamily normalization ---
     if "subfamily_de" in df.columns:
         subfam = df["subfamily_de"].fillna("")
@@ -147,6 +153,31 @@ def annotate_events(df: pd.DataFrame) -> pd.DataFrame:
         fam_src = pd.Series([""] * len(df), index=df.index)
 
     fam = fam_src.astype(str).str.lower().str.replace("-", "_", regex=False)
+
+    # --- V2 API Event Action Type (for robust foul classification) ---
+    action_type = df.get("eventmsgactiontype")
+    if action_type is not None:
+        try:
+            action_type = pd.to_numeric(action_type, errors="coerce")
+            # Use Int64 (nullable integer type) if possible for robust handling of NaNs
+            if action_type.isnull().any():
+                try:
+                    action_type = action_type.astype("Int64")
+                except TypeError:
+                    # pandas too old, keep as float
+                    pass
+        except Exception:
+            # If conversion fails completely, set to None
+            action_type = None
+
+    # Helper to safely check action type equality or inclusion
+    def _check_action_type(val_or_list):
+        if action_type is None:
+            return pd.Series(False, index=df.index)
+        if isinstance(val_or_list, (list, set, tuple)):
+            return action_type.isin(val_or_list)
+        return action_type == val_or_list
+
     df["family"] = fam
 
     # --- Event team id ---
@@ -226,21 +257,26 @@ def annotate_events(df: pd.DataFrame) -> pd.DataFrame:
 
     # Identify the last free-throw attempt in a trip so rebound opportunities
     # can include missed end-of-trip free throws.
+
+    # Fallback heuristic based on text
+    sub_lower = subfam.astype(str).str.lower()
+    heuristic_last_ft = df["is_ft"] & (
+        sub_lower.str.contains("1 of 1")
+        | sub_lower.str.contains("2 of 2")
+        | sub_lower.str.contains("3 of 3")
+    )
+
     if "ft_n" in df.columns and "ft_m" in df.columns:
         try:
             ft_n = df["ft_n"].fillna(0).astype(int)
             ft_m = df["ft_m"].fillna(0).astype(int)
             df["is_last_ft"] = (ft_n == ft_m) & (ft_n > 0)
         except (ValueError, TypeError):
-            df["is_last_ft"] = False
+            # If conversion fails (e.g., bad data), use the heuristic fallback
+            df["is_last_ft"] = heuristic_last_ft
     else:
-        # Fallback heuristic when counters are missing: look for "X of X" text.
-        sub_lower = subfam.astype(str).str.lower()
-        df["is_last_ft"] = df["is_ft"] & (
-            sub_lower.str.contains("1 of 1")
-            | sub_lower.str.contains("2 of 2")
-            | sub_lower.str.contains("3 of 3")
-        )
+        # Fallback heuristic when counters are missing
+        df["is_last_ft"] = heuristic_last_ft
 
     if "is_o_rebound" not in df.columns:
         df["is_o_rebound"] = 0
@@ -255,7 +291,8 @@ def annotate_events(df: pd.DataFrame) -> pd.DataFrame:
         dist = df.get("shot_distance")
         if dist is not None:
             dist_num = pd.to_numeric(dist, errors="coerce")
-            df["is_three"] = (dist_num >= 23.0) & df["is_fg_attempt"]
+            # Use 23.75 feet as the threshold for above-the-break threes.
+            df["is_three"] = (dist_num >= 23.75) & df["is_fg_attempt"]
         else:
             df["is_three"] = False
 
@@ -269,8 +306,12 @@ def annotate_events(df: pd.DataFrame) -> pd.DataFrame:
     is_steal_flag = steal_col.fillna(0).astype(int) == 1
 
     sub_lower = subfam.astype(str).str.lower()
-    # Some feeds may explicitly label "live-ball" in text.
-    sub_live_flag = sub_lower.str.contains("live")
+    # Expanded criteria for live-ball turnovers based on common subfamily descriptions.
+    sub_live_flag = (
+        sub_lower.str.contains("live")
+        | sub_lower.str.contains("bad pass")
+        | sub_lower.str.contains("lost ball")
+    )
 
     df["is_turnover_live"] = is_tov_family & (is_steal_flag | sub_live_flag)
     df["is_turnover_dead"] = is_tov_family & ~df["is_turnover_live"]
@@ -278,15 +319,45 @@ def annotate_events(df: pd.DataFrame) -> pd.DataFrame:
     # --- Foul flavors ---
     is_foul_family = fam == "foul"
     sub = sub_lower
-    df["is_loose_ball_foul"] = is_foul_family & sub.str.contains("loose")
-    df["is_flagrant"] = is_foul_family & sub.str.contains("flagrant")
-    df["is_technical"] = is_foul_family & sub.str.contains("technical")
+
+    # Loose ball foul (v2 type 6)
+    df["is_loose_ball_foul"] = is_foul_family & (
+        sub.str.contains("loose") | _check_action_type(6)
+    )
+
+    # Flagrant fouls (v2 types 11-15, 27-29)
+    flagrant_types = {11, 12, 13, 14, 15, 27, 28, 29}
+    df["is_flagrant"] = is_foul_family & (
+        sub.str.contains("flagrant") | _check_action_type(flagrant_types)
+    )
+
+    # Technical fouls (v2 types 16, 18-20, 25, 30).
+    technical_types = {16, 18, 19, 20, 25, 30}
+    df["is_technical"] = is_foul_family & (
+        sub.str.contains("technical") | _check_action_type(technical_types)
+    )
+
+    # Charging/Offensive fouls (v2 type 2)
     charge_mask = sub.str.contains(r"\bcharging\b") | sub.str.contains(r"\bcharge\b")
-    df["is_charge"] = is_foul_family & charge_mask
+    df["is_charge"] = is_foul_family & (charge_mask | _check_action_type(2))
 
     # --- And-ones via qualifiers ---
-    quals_series = df["qualifiers"] if "qualifiers" in df.columns else pd.Series([None] * len(df), index=df.index)
+    if "qualifiers" in df.columns:
+        quals_series = df["qualifiers"]
+    else:
+        quals_series = pd.Series([None] * len(df), index=df.index)
     df["is_and_one"] = _vectorized_is_and_one(quals_series)
+
+    # --- Goaltends (Centralized) ---
+    goaltend_flag = sub.str.contains("goaltend")
+    # CDN feeds may encode goaltends via qualifiers instead of subfamily.
+    if "qualifiers" in df.columns:
+        # Handle various qualifier formats (list, string, or NaN) robustly
+        quals_str = df["qualifiers"].apply(
+            lambda x: str(x).lower() if not pd.isna(x) else ""
+        )
+        goaltend_flag = goaltend_flag | quals_str.str.contains("goaltend")
+    df["is_goaltend"] = goaltend_flag
 
     # --- Shot zones ---
     shot_mask = df["is_fg_attempt"]
@@ -300,14 +371,16 @@ def annotate_events(df: pd.DataFrame) -> pd.DataFrame:
     df["off_team_id"] = np.where(off_mask, df["team_id"], np.nan)
     df["def_team_id"] = np.where(
         off_mask,
-        np.where(df["off_team_id"] == df["home_team_id"], df["away_team_id"], df["home_team_id"]),
+        np.where(
+            df["off_team_id"] == df["home_team_id"], df["away_team_id"], df["home_team_id"]
+        ),
         np.nan,
     )
 
     return df
 
 
-def _increment_count(counter: Dict[str, float], key: str, value: float = 1.0):
+def _increment_count(counter: Dict[str, float], key: str, value: float = 1.0) -> None:
     counter[key] += value
 
 
@@ -320,14 +393,16 @@ def _valid_player_id(pid: Any) -> bool:
     """
     if pid is None:
         return False
+
+    # Use pandas.isna for robust checking of NaN/None across types
+    if pd.isna(pid):
+        return False
+
     try:
-        if pd.isna(pid):
-            return False
-    except TypeError:
-        pass
-    try:
+        # Attempt to convert to integer and check if it's non-zero
         return int(pid) != 0
     except (TypeError, ValueError):
+        # Handle cases where conversion fails (e.g., strings that are not numbers)
         return False
 
 
@@ -339,8 +414,10 @@ def accumulate_player_counts(df: pd.DataFrame) -> pd.DataFrame:
         player_id = row.get("player1_id")
         team_id = row.get("player1_team_id")
         game_id = row.get("game_id")
-        if pd.isna(player_id) or player_id == 0:
+
+        if not _valid_player_id(player_id):
             player_id = None
+
         key = (game_id, team_id, player_id)
 
         if row.get("is_fg_attempt"):
@@ -368,11 +445,11 @@ def accumulate_player_counts(df: pd.DataFrame) -> pd.DataFrame:
             if is_make:
                 assist_id = row.get("assist_id")
                 shooter = row.get("player1_id")
-                if pd.isna(assist_id) or assist_id in (0, shooter):
+                if not _valid_player_id(assist_id) or assist_id == shooter:
                     assist_id = None
                     if "player2_id" in row.index:
                         p2 = row.get("player2_id")
-                        if not pd.isna(p2) and p2 not in (0, shooter):
+                        if _valid_player_id(p2) and p2 != shooter:
                             assist_id = p2
 
             assisted = is_make and _valid_player_id(assist_id)
@@ -386,7 +463,8 @@ def accumulate_player_counts(df: pd.DataFrame) -> pd.DataFrame:
                     _increment_count(counts[key], f"{zone}_FGM_AST")
 
                 # Passer-level AST counts (by zone + 3P)
-                ast_key = (game_id, row.get("team_id"), int(assist_id))
+                # The assister is on the same team as the shooter (player1_team_id)
+                ast_key = (game_id, row.get("player1_team_id"), int(assist_id))
                 _increment_count(counts[ast_key], "AST")
                 if zone:
                     _increment_count(counts[ast_key], f"AST_{zone}")
@@ -419,7 +497,7 @@ def accumulate_player_counts(df: pd.DataFrame) -> pd.DataFrame:
             elif row.get("points_made", 0) > 0:
                 _increment_count(counts[key], "FTM")
 
-        if not pd.isna(player_id):
+        if _valid_player_id(player_id):
             _increment_count(counts[key], "PTS", row.get("points_made", 0))
 
         if row.get("is_o_rebound") == 1:
@@ -427,14 +505,14 @@ def accumulate_player_counts(df: pd.DataFrame) -> pd.DataFrame:
         if row.get("is_d_rebound") == 1:
             _increment_count(counts[key], "DREB")
 
-        if row.get("family") == "turnover" and not pd.isna(player_id):
+        if row.get("family") == "turnover" and _valid_player_id(player_id):
             _increment_count(counts[key], "TOV")
             if row.get("is_turnover_live"):
                 _increment_count(counts[key], "TOV_Live")
             else:
                 _increment_count(counts[key], "TOV_Dead")
 
-        if row.get("family") == "foul" and not pd.isna(player_id):
+        if row.get("family") == "foul" and _valid_player_id(player_id):
             # Player 1 commits the foul
             _increment_count(counts[key], "PF")
             if row.get("is_loose_ball_foul"):
@@ -446,7 +524,7 @@ def accumulate_player_counts(df: pd.DataFrame) -> pd.DataFrame:
 
             fouled = row.get("player2_id")
             fouled_team = row.get("player2_team_id")
-            if fouled and not pd.isna(fouled) and fouled_team and not pd.isna(fouled_team):
+            if _valid_player_id(fouled) and not pd.isna(fouled_team):
                 foul_key = (game_id, fouled_team, fouled)
                 # Generic foul drawn
                 _increment_count(counts[foul_key], "PF_DRAWN")
@@ -461,7 +539,7 @@ def accumulate_player_counts(df: pd.DataFrame) -> pd.DataFrame:
             possession_after = row.get("possession_after")
             shooter_team = row.get("team_id")
 
-            if _valid_player_id(blocker):
+            if _valid_player_id(blocker) and not pd.isna(block_team):
                 block_key = (game_id, block_team, int(blocker))
                 _increment_count(counts[block_key], "BLK")
                 if possession_after and possession_after == block_team:
@@ -469,43 +547,49 @@ def accumulate_player_counts(df: pd.DataFrame) -> pd.DataFrame:
                 elif possession_after and possession_after == shooter_team:
                     _increment_count(counts[block_key], "BLK_Opp")
                 else:
+                    # If possession_after is unknown, default to BLK_Team (assume defensive recovery).
                     _increment_count(counts[block_key], "BLK_Team")
 
         if row.get("is_steal") == 1:
             stealer = row.get("player2_id")
             steal_team = row.get("player2_team_id")
-            if _valid_player_id(stealer):
+            if _valid_player_id(stealer) and not pd.isna(steal_team):
                 steal_key = (game_id, steal_team, int(stealer))
                 _increment_count(counts[steal_key], "STL")
 
-        subfamily = row.get("subfamily_de") or row.get("subfamily")
-        goaltend_flag = isinstance(subfamily, str) and "goaltend" in subfamily.lower()
+        # Use the centralized is_goaltend flag
+        if row.get("is_goaltend"):
+            # Goaltends are typically credited to player3 (defensive) or player1 (offensive violation)
+            # Determine the responsible player and team.
+            goaltend_player = None
+            goaltend_team = None
 
-        # CDN feeds may encode goaltends via qualifiers instead of subfamily.
-        if not goaltend_flag:
-            quals = row.get("qualifiers")
-            if isinstance(quals, str):
-                goaltend_flag = "goaltend" in quals.lower()
-            else:
-                try:
-                    goaltend_flag = any("goaltend" in str(q).lower() for q in quals)
-                except TypeError:
-                    pass
+            # Defensive goaltending (player3)
+            p3_id = row.get("player3_id")
+            if _valid_player_id(p3_id):
+                goaltend_player = p3_id
+                goaltend_team = row.get("player3_team_id")
+            # Offensive goaltending/basket interference (player1)
+            elif _valid_player_id(player_id):
+                goaltend_player = player_id
+                goaltend_team = team_id
 
-        if goaltend_flag:
-            goaltend_player = row.get("player3_id") or row.get("player1_id")
-            goaltend_team = row.get("player3_team_id") or row.get("player1_team_id")
-            gt_key = (game_id, goaltend_team, goaltend_player)
-            _increment_count(counts[gt_key], "Goaltends")
+            if (
+                _valid_player_id(goaltend_player)
+                and goaltend_team is not None
+                and not pd.isna(goaltend_team)
+            ):
+                gt_key = (game_id, goaltend_team, int(goaltend_player))
+                _increment_count(counts[gt_key], "Goaltends")
 
-        if row.get("is_fg_make") and row.get("is_and_one") and not pd.isna(player_id):
+        if row.get("is_fg_make") and row.get("is_and_one") and _valid_player_id(player_id):
             _increment_count(counts[key], "AndOnes")
 
     records: List[Dict[str, Any]] = []
     for (game_id, team_id, player_id), vals in counts.items():
-        if player_id is None or player_id == 0:
+        if not _valid_player_id(player_id):
             continue
-        record = {
+        record: Dict[str, Any] = {
             "game_id": game_id,
             "team_id": team_id,
             "player_id": player_id,
@@ -1118,11 +1202,35 @@ def append_team_totals(box_df: pd.DataFrame) -> pd.DataFrame:
         0.0,
     )
     team_totals["POSS"] = team_totals["POSS_OFF"] + team_totals["POSS_DEF"]
+
+    # Use offensive possessions for team pace so we don't double-count.
     team_totals["Pace"] = np.where(
         team_totals["Minutes"] > 0,
-        team_totals["POSS"] / team_totals["Minutes"] * 48.0,
+        team_totals["POSS_OFF"] / team_totals["Minutes"] * 48.0,
         0.0,
     )
+
+    # Recompute team-level shooting percentages (avoid summed player rates).
+    team_totals["FGPct"] = np.where(
+        team_totals["FGA"] > 0,
+        team_totals["FGM"] / team_totals["FGA"],
+        0.0,
+    )
+    team_totals["FT_pct"] = np.where(
+        team_totals["FTA"] > 0,
+        team_totals["FTM"] / team_totals["FTA"],
+        0.0,
+    )
+    team_totals["FT%"] = team_totals["FT_pct"]
+
+    if "ThreePM" in team_totals.columns and "ThreePA" in team_totals.columns:
+        team_totals["ThreeP_pct"] = np.where(
+            team_totals["ThreePA"] > 0,
+            team_totals["ThreePM"] / team_totals["ThreePA"],
+            0.0,
+        )
+        team_totals["3PPct"] = team_totals["ThreeP_pct"]
+
     team_totals["PTS_100p"] = np.where(
         team_totals["POSS_OFF"] > 0,
         team_totals["PTS"] / team_totals["POSS_OFF"] * 100.0,

--- a/nba_parser/pbp.py
+++ b/nba_parser/pbp.py
@@ -7,6 +7,7 @@ from .box_glossary import (
     accumulate_player_counts,
     compute_on_court_exposures,
     build_player_box,
+    append_team_totals,
 )
 
 # NOTE:
@@ -106,7 +107,8 @@ class PbP:
             self.df.loc[away_pos_idx, "away_possession"] = 1
 
         else:
-            # --- LEGACY HEURISTIC POSSESSION FLAGS (existing code path) ---
+            # --- LEGACY HEURISTIC POSSESSION FLAGS (existing v2-style code path) ---
+
             # calculating made shot possessions
             self.df["home_possession"] = np.where(
                 (self.df.event_team == self.df.home_team_abbrev)
@@ -114,6 +116,7 @@ class PbP:
                 1,
                 0,
             )
+
             # calculating turnover possessions
             self.df["home_possession"] = np.where(
                 (self.df.event_team == self.df.home_team_abbrev)
@@ -121,6 +124,7 @@ class PbP:
                 1,
                 self.df["home_possession"],
             )
+
             # calculating defensive rebound possessions
             self.df["home_possession"] = np.where(
                 (
@@ -137,31 +141,68 @@ class PbP:
                 1,
                 self.df["home_possession"],
             )
-            # calculating final free throw possessions
+
+            # Determine if it's the last free throw using structured data if available
+            is_last_ft = pd.Series(False, index=self.df.index)
+
+            # Ensure descriptions are treated as strings and handle NaNs
+            homedesc = self.df.get("homedescription", pd.Series(index=self.df.index)).fillna("").astype(str)
+            visitordesc = self.df.get("visitordescription", pd.Series(index=self.df.index)).fillna("").astype(str)
+
+            # Heuristic fallback using string matching
+            string_match_last_ft = (
+                homedesc.str.contains("Free Throw 1 of 1")
+                | homedesc.str.contains("Free Throw 2 of 2")
+                | homedesc.str.contains("Free Throw 3 of 3")
+                | visitordesc.str.contains("Free Throw 1 of 1")
+                | visitordesc.str.contains("Free Throw 2 of 2")
+                | visitordesc.str.contains("Free Throw 3 of 3")
+            )
+
+            if "ft_n" in self.df.columns and "ft_m" in self.df.columns:
+                try:
+                    ft_n = self.df["ft_n"].fillna(0).astype(int)
+                    ft_m = self.df["ft_m"].fillna(0).astype(int)
+                    structured_last_ft = (ft_n == ft_m) & (ft_n > 0)
+                    # Use structured data if valid, otherwise fallback to string match
+                    is_last_ft = np.where(
+                        (ft_n > 0) & (ft_m > 0),
+                        structured_last_ft,
+                        string_match_last_ft,
+                    )
+                except (ValueError, TypeError):
+                    # Fallback if structured data is malformed
+                    is_last_ft = string_match_last_ft
+            else:
+                # Fallback if columns are missing
+                is_last_ft = string_match_last_ft
+
+            # calculating final free throw possessions (Home)
             self.df["home_possession"] = np.where(
                 (self.df.event_team == self.df.home_team_abbrev)
-                & (
-                    (self.df.homedescription.str.contains("Free Throw 2 of 2"))
-                    | (self.df.homedescription.str.contains("Free Throw 3 of 3"))
-                ),
+                & (self.df.event_type_de == "free-throw")
+                & is_last_ft,
                 1,
                 self.df["home_possession"],
             )
-            # calculating made shot possessions
+
+            # calculating made shot possessions (Away)
             self.df["away_possession"] = np.where(
                 (self.df.event_team == self.df.away_team_abbrev)
                 & (self.df.event_type_de == "shot"),
                 1,
                 0,
             )
-            # calculating turnover possessions
+
+            # calculating turnover possessions (Away)
             self.df["away_possession"] = np.where(
                 (self.df.event_team == self.df.away_team_abbrev)
                 & (self.df.event_type_de == "turnover"),
                 1,
                 self.df["away_possession"],
             )
-            # calculating defensive rebound possessions
+
+            # calculating defensive rebound possessions (Away)
             self.df["away_possession"] = np.where(
                 (
                     (self.df.event_team == self.df.home_team_abbrev)
@@ -177,13 +218,12 @@ class PbP:
                 1,
                 self.df["away_possession"],
             )
-            # calculating final free throw possessions
+
+            # calculating final free throw possessions (Away)
             self.df["away_possession"] = np.where(
                 (self.df.event_team == self.df.away_team_abbrev)
-                & (
-                    (self.df.visitordescription.str.contains("Free Throw 2 of 2"))
-                    | (self.df.visitordescription.str.contains("Free Throw 3 of 3"))
-                ),
+                & (self.df.event_type_de == "free-throw")
+                & is_last_ft,
                 1,
                 self.df["away_possession"],
             )
@@ -1055,7 +1095,7 @@ class PbP:
         return plus_minus_df[["team_id", "game_id", "points_against", "plus_minus"]]
 
     @staticmethod
-    def _get_off_def_teams(last_event):
+    def _get_off_def_teams(last_event: pd.Series) -> tuple[str, str]:
         """
         Determine offensive and defensive team abbreviations for a possession
         based on the last event in that possession.
@@ -1072,21 +1112,40 @@ class PbP:
         ev_type = last_event.get("family") or last_event.get("event_type_de")
         if isinstance(ev_type, str):
             ev_type = ev_type.replace("-", "_").lower()
+        else:
+            ev_type = ""
 
         # Default offense/defense mapping mirrors existing _build_possessions logic:
         # - shot / free_throw / turnover: offense is event_team
-        # - rebound: offense is the other team
+        # - rebound: depends on OREB/DREB flags
         # - fallback: treat event_team as offense
         if ev_type in ("shot", "miss_shot", "missed_shot", "free_throw", "turnover"):
             off_abbrev = ev_team
         elif ev_type == "rebound":
-            if ev_team == home_abbrev:
-                off_abbrev = away_abbrev
-            elif ev_team == away_abbrev:
-                off_abbrev = home_abbrev
-            else:
-                # If we can't match, fall back to event team
+            # Check rebound type flags (Critical Fix)
+            is_d_rebound = last_event.get("is_d_rebound") == 1
+            is_o_rebound = last_event.get("is_o_rebound") == 1
+
+            if is_o_rebound:
+                # Offensive rebound: the rebounding team is offense.
                 off_abbrev = ev_team
+            elif is_d_rebound:
+                # Defensive rebound: the rebounding team is defense, the other team was offense.
+                if ev_team == home_abbrev:
+                    off_abbrev = away_abbrev
+                elif ev_team == away_abbrev:
+                    off_abbrev = home_abbrev
+                else:
+                    # If we can't match, fall back to event team
+                    off_abbrev = ev_team
+            else:
+                # Ambiguous/Team rebound: Treat similar to DREB for determining who *had* the ball.
+                if ev_team == home_abbrev:
+                    off_abbrev = away_abbrev
+                elif ev_team == away_abbrev:
+                    off_abbrev = home_abbrev
+                else:
+                    off_abbrev = ev_team
         else:
             off_abbrev = ev_team
 
@@ -1111,25 +1170,35 @@ class PbP:
         return off_abbrev, def_abbrev
 
     @staticmethod
-    def parse_possessions(poss_list):
+    def parse_possessions(poss_list: list[pd.DataFrame]) -> tuple[list[pd.DataFrame], list[int]]:
         """
-        a function to parse each possession and create one row for offense team
-        and defense team
+        Parse each possession segment and create one row for offense team
+        and defense team lineups.
 
         Inputs:
-        poss_list   - list of dataframes each one representing one possession
+            poss_list   - list of dataframes each one representing one possession
 
         Outputs:
-        parsed_list  - list of dataframes where each list inside represents the players on
-                       off and def and points score for each possession
-        used_indices - list of integer indices into poss_list corresponding to parsed_list
+            parsed_list  - list of single-row dataframes, one per possession
+            used_indices - list of integer indices into poss_list corresponding to parsed_list
         """
-        parsed_list = []
-        used_indices = []
+        parsed_list: list[pd.DataFrame] = []
+        used_indices: list[int] = []
+
+        # Define metadata columns to carry through
+        metadata_cols = [
+            "points_made",
+            "home_team_abbrev",
+            "event_team",
+            "away_team_abbrev",
+            "home_team_id",
+            "away_team_id",
+            "game_id",
+            "game_date",
+            "season",
+        ]
 
         # Explicit list of player columns so we do not rely on column order
-        # in the source DataFrame. This matches the expected order used when
-        # constructing off_player_* and def_player_* fields below.
         player_cols = [
             "home_player_1", "home_player_1_id",
             "home_player_2", "home_player_2_id",
@@ -1142,6 +1211,15 @@ class PbP:
             "away_player_4", "away_player_4_id",
             "away_player_5", "away_player_5_id",
         ]
+
+        # Dynamically generate column mappings for renaming
+        home_to_off = {c: c.replace("home_", "off_") for c in player_cols if "home_" in c}
+        away_to_def = {c: c.replace("away_", "def_") for c in player_cols if "away_" in c}
+        home_to_def = {c: c.replace("home_", "def_") for c in player_cols if "home_" in c}
+        away_to_off = {c: c.replace("away_", "off_") for c in player_cols if "away_" in c}
+
+        # Combine player and metadata columns for selection
+        selected_cols = player_cols + metadata_cols
 
         for seg_idx, df in enumerate(poss_list):
             if df.empty:
@@ -1170,107 +1248,31 @@ class PbP:
             # Determine offense/defense using centralized helper
             off_abbrev, _ = PbP._get_off_def_teams(last_event)
 
-            def append_possession(off_abbrev: str):
+            def append_possession(off_abbrev_inner: str) -> None:
                 home_abbrev = last_event.get("home_team_abbrev")
                 away_abbrev = last_event.get("away_team_abbrev")
 
-                if off_abbrev not in (home_abbrev, away_abbrev):
+                if off_abbrev_inner not in (home_abbrev, away_abbrev):
                     # Fallback: assume home is on offense to preserve row count
-                    off_abbrev = home_abbrev
+                    off_abbrev_inner = home_abbrev
 
-                row_df = pd.concat(
-                    [
-                        last_event[player_cols],
-                        last_event[
-                            [
-                                "points_made",
-                                "home_team_abbrev",
-                                "event_team",
-                                "away_team_abbrev",
-                                "home_team_id",
-                                "away_team_id",
-                                "game_id",
-                                "game_date",
-                                "season",
-                            ]
-                        ],
-                    ]
-                )
+                # Create a DataFrame from the last event's relevant columns
+                # Handle potential missing columns gracefully
+                data = {col: last_event.get(col) for col in selected_cols}
+                row_df = pd.DataFrame([data])
 
-                if off_abbrev == home_abbrev:
-                    parsed_list.append(
-                        pd.DataFrame(
-                            [list(row_df)],
-                            columns=[
-                                "off_player_1",
-                                "off_player_1_id",
-                                "off_player_2",
-                                "off_player_2_id",
-                                "off_player_3",
-                                "off_player_3_id",
-                                "off_player_4",
-                                "off_player_4_id",
-                                "off_player_5",
-                                "off_player_5_id",
-                                "def_player_1",
-                                "def_player_1_id",
-                                "def_player_2",
-                                "def_player_2_id",
-                                "def_player_3",
-                                "def_player_3_id",
-                                "def_player_4",
-                                "def_player_4_id",
-                                "def_player_5",
-                                "def_player_5_id",
-                                "points_made",
-                                "home_team_abbrev",
-                                "event_team_abbrev",
-                                "away_team_abbrev",
-                                "home_team_id",
-                                "away_team_id",
-                                "game_id",
-                                "game_date",
-                                "season",
-                            ],
-                        )
-                    )
+                # Rename 'event_team' to 'event_team_abbrev' for consistency if needed
+                if "event_team" in row_df.columns and "event_team_abbrev" not in row_df.columns:
+                    row_df = row_df.rename(columns={"event_team": "event_team_abbrev"})
+
+                if off_abbrev_inner == home_abbrev:
+                    # Home team on offense
+                    row_df = row_df.rename(columns={**home_to_off, **away_to_def})
                 else:
-                    parsed_list.append(
-                        pd.DataFrame(
-                            [list(row_df)],
-                            columns=[
-                                "def_player_1",
-                                "def_player_1_id",
-                                "def_player_2",
-                                "def_player_2_id",
-                                "def_player_3",
-                                "def_player_3_id",
-                                "def_player_4",
-                                "def_player_4_id",
-                                "def_player_5",
-                                "def_player_5_id",
-                                "off_player_1",
-                                "off_player_1_id",
-                                "off_player_2",
-                                "off_player_2_id",
-                                "off_player_3",
-                                "off_player_3_id",
-                                "off_player_4",
-                                "off_player_4_id",
-                                "off_player_5",
-                                "off_player_5_id",
-                                "points_made",
-                                "home_team_abbrev",
-                                "event_team_abbrev",
-                                "away_team_abbrev",
-                                "home_team_id",
-                                "away_team_id",
-                                "game_id",
-                                "game_date",
-                                "season",
-                            ],
-                        )
-                    )
+                    # Away team on offense
+                    row_df = row_df.rename(columns={**away_to_off, **home_to_def})
+
+                parsed_list.append(row_df)
 
             append_possession(off_abbrev)
 
@@ -1302,14 +1304,47 @@ class PbP:
                 shift_dfs.append(seg)
             past_index = i
 
-        parsed_possessions, used_indices = self.parse_possessions(shift_dfs)
+        # --- NEW: normalize segments so parse_possessions and event_aggs see the same slice ---
+        valid_end_types = {
+            "rebound",
+            "turnover",
+            "shot",
+            "free-throw",
+            "free_throw",
+            "missed_shot",
+            "miss_shot",
+        }
+
+        normalized_segments: list[pd.DataFrame] = []
+        for seg in shift_dfs:
+            if seg.empty or "event_type_de" not in seg.columns:
+                normalized_segments.append(seg)
+                continue
+
+            last_type = str(seg["event_type_de"].iloc[-1])
+            if last_type in valid_end_types:
+                normalized_segments.append(seg)
+                continue
+
+            mask = seg["event_type_de"].isin(valid_end_types)
+            if not mask.any():
+                # No terminal events in this stretch; treat as empty so
+                # it won't generate a possession row.
+                normalized_segments.append(seg.iloc[0:0])
+                continue
+
+            last_idx = mask[mask].index[-1]
+            normalized_segments.append(seg.loc[: last_idx].copy())
+
+        # Use normalized segments everywhere downstream
+        parsed_possessions, used_indices = self.parse_possessions(normalized_segments)
 
         # If no possessions were detected, return an empty DataFrame
         if not parsed_possessions:
             return pd.DataFrame()
 
         event_aggs = []
-        for poss_df in shift_dfs:
+        for poss_df in normalized_segments:
             poss_events = poss_df  # already annotated via pbp_df
             if poss_events.empty:
                 event_aggs.append(
@@ -1605,6 +1640,23 @@ class PbP:
         self._check_on_court_minutes_consistency(box_df)
 
         return box_df
+
+    def player_box_glossary_with_totals(
+        self,
+        player_meta: pd.DataFrame | None = None,
+        game_meta: pd.DataFrame | None = None,
+        player_game_meta: pd.DataFrame | None = None,
+    ) -> pd.DataFrame:
+        """
+        Convenience wrapper: build the per-player glossary box and append one
+        'TOTAL' row per (game_id, team_id).
+        """
+        box = self.player_box_glossary(
+            player_meta=player_meta,
+            game_meta=game_meta,
+            player_game_meta=player_game_meta,
+        )
+        return append_team_totals(box)
 
     def _check_on_court_points_consistency(self, box: pd.DataFrame, tol: float = 1e-6) -> None:
         """


### PR DESCRIPTION
## Summary
- refresh glossary helpers and player count accumulation logic for consistent event annotation and shot zoning
- update possession parsing to normalize segments, infer offense/defense on rebounds, and add a totals wrapper
- recompute team totals pace and shooting percentages from aggregate values

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c5ff5bb248328b4817bce01b2308e)