### PR TITLE
Use Series masking for shot zone assignment

### DIFF
--- a/nba_parser/box_glossary.py
+++ b/nba_parser/box_glossary.py
@@ -364,7 +364,9 @@ def annotate_events(df: pd.DataFrame) -> pd.DataFrame:
     # --- Shot zones ---
     shot_mask = df["is_fg_attempt"]
     if "shot_distance" in df.columns or "area" in df.columns:
-        df["shot_zone"] = np.where(shot_mask, _vectorized_shot_zone(df), None)
+        zones = _vectorized_shot_zone(df)
+        zones = zones.where(shot_mask, None)
+        df["shot_zone"] = zones
     else:
         df["shot_zone"] = None
 


### PR DESCRIPTION
## Summary
- switch shot zone assignment to use Series masking for clearer handling of non-FGA rows
- keep shot zone index alignment while avoiding np.where array coercion

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c6e9792788328938cae737f407bb0)