### PR TITLE
Normalize team and player ID casting

### DIFF
--- a/nba_parser/box_glossary.py
+++ b/nba_parser/box_glossary.py
@@ -797,9 +797,11 @@ def build_player_box(
     merged[num_cols] = merged[num_cols].fillna(0)
     merged = merged[(merged["team_id"] != 0) & (merged["player_id"] != 0)]
 
-    for col in ["game_id", "team_id", "player_id"]:
+    # Normalize team/player ids to ints, but leave game_id as-is
+    # (it’s usually a zero-padded string like '0021900151').
+    for col in ["team_id", "player_id"]:
         if col in merged.columns:
-            merged[col] = merged[col].astype(int)
+            merged[col] = pd.to_numeric(merged[col], errors="coerce").fillna(0).astype(int)
 
     # Identify any rows where a player has on-court points credited but no minutes.
     # In clean data this should be rare; it typically indicates a mismatch between


### PR DESCRIPTION
## Summary
- keep game_id as its original dtype while casting team/player ids to integers
- coerce team/player ids with to_numeric to avoid merge dtype conflicts

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c74a7b6a48328b8536501bacadb6f)